### PR TITLE
NotifyIcon

### DIFF
--- a/VL.WinFormsUtils.vl
+++ b/VL.WinFormsUtils.vl
@@ -2934,7 +2934,7 @@
         </p:NodeReference>
         <Patch Id="S3MSkIg2KX8MVm85Cpo7aZ">
           <Canvas Id="N8j6EYB8TDRMX2j3Q8o79l" CanvasType="Group">
-            <Node Bounds="110,31,53,26" Id="PfaTq1vuroMN5FdOnxaFQY">
+            <Node Bounds="98,239,53,26" Id="PfaTq1vuroMN5FdOnxaFQY">
               <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
@@ -2942,9 +2942,9 @@
               </p:NodeReference>
               <Pin Id="Ru0SLUzybYrNoYQeOZAZEa" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Pad Id="QFLdDnx7Oi1L3CUeitj8Ep" SlotId="RKdZV3j8OxFMqGtsZTYtPK" Bounds="112,86" />
-            <ControlPoint Id="A7Cf2reAgiRO67htuFIezG" Bounds="225,44" />
-            <Node Bounds="223,82,74,26" Id="BrzParhQGEJLGW6TNYbrgr">
+            <Pad Id="QFLdDnx7Oi1L3CUeitj8Ep" SlotId="RKdZV3j8OxFMqGtsZTYtPK" Bounds="100,294" />
+            <ControlPoint Id="A7Cf2reAgiRO67htuFIezG" Bounds="213,177" />
+            <Node Bounds="211,275,74,26" Id="BrzParhQGEJLGW6TNYbrgr">
               <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastSymbolSource="System.Windows.Forms.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="WindowState" />
@@ -2954,7 +2954,7 @@
               <Pin Id="FKsTvJSEOgoPEMLVjcpv79" Name="Output" Kind="StateOutputPin" />
               <Pin Id="EAuiAIb1fsbMaFmy5MJSY5" Name="Window State" Kind="OutputPin" />
             </Node>
-            <Node Bounds="292,120,25,19" Id="FAYgweJLpAkNzh0jLugZjh">
+            <Node Bounds="280,313,25,19" Id="FAYgweJLpAkNzh0jLugZjh">
               <p:NodeReference LastCategoryFullName="System.Windows.Forms.FormWindowState" LastSymbolSource="System.Windows.Forms.dll">
                 <CategoryReference Kind="AssemblyCategory" Name="FormWindowState" />
                 <Choice Kind="OperationCallFlag" Name="=" />
@@ -2967,8 +2967,8 @@
               </Pin>
               <Pin Id="LO3EEWLRPv6M0oqyQgGh93" Name="Result" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="F44Od8e6KaEL0iusVzCVAp" Bounds="326,65" />
-            <Node Bounds="292,153,37,19" Id="AlEmZfRhlqhNo4wNZZVjh8">
+            <ControlPoint Id="F44Od8e6KaEL0iusVzCVAp" Bounds="314,177" />
+            <Node Bounds="280,345,37,19" Id="AlEmZfRhlqhNo4wNZZVjh8">
               <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="AND" />
@@ -2977,8 +2977,8 @@
               <Pin Id="V0Dr2y22VzsLQbw5UZIRHy" Name="Input 2" Kind="InputPin" />
               <Pin Id="P92G6CBzwcFPvAt7jeCM93" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <ControlPoint Id="U0UAfXWIeLkPyvSZ2xkRLV" Bounds="349,164" />
-            <Node Bounds="292,195,60,19" Id="CCbWthfK88VNnbAt5d1ytw">
+            <ControlPoint Id="U0UAfXWIeLkPyvSZ2xkRLV" Bounds="337,357" />
+            <Node Bounds="280,388,60,19" Id="CCbWthfK88VNnbAt5d1ytw">
               <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="OR" />
@@ -2987,7 +2987,7 @@
               <Pin Id="Sne3mzcRCaaOB8ddOLzVAt" Name="Input 2" Kind="InputPin" />
               <Pin Id="I6JWuglCFSRMwWbOdRpYrj" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="110,242,187,26" Id="N0UjbSpFf3NPArfPa5LGWF">
+            <Node Bounds="98,435,187,26" Id="N0UjbSpFf3NPArfPa5LGWF">
               <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
@@ -2997,7 +2997,7 @@
               <Pin Id="Q3ZvUBY5sGOMK4AQ4DoRKS" Name="Value" Kind="InputPin" />
               <Pin Id="LyeU9D0sVyTMf00M6lYVJq" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="98,423,77,106" Id="EAEVeWDT93vLGMT0Swfgyp">
+            <Node Bounds="86,631,77,106" Id="EAEVeWDT93vLGMT0Swfgyp">
               <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ProcessStatefulRegion" Name="Cache" />
@@ -3009,7 +3009,7 @@
               <Patch Id="JLUkDOWIkCbL0QghqMO7O9" ManuallySortedPins="true">
                 <Patch Id="FOCKU0gxo4hNXdH9s7GdKa" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="VQg4buXZyP5PxoNKARe667" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="110,461,53,26" Id="DSigSz82AVBM9GgMOVxSP5">
+                <Node Bounds="98,669,53,26" Id="DSigSz82AVBM9GgMOVxSP5">
                   <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
@@ -3020,11 +3020,11 @@
                   <Pin Id="KvfsZFF41mWLgGpMJJboQ2" Name="Output" Kind="StateOutputPin" />
                 </Node>
               </Patch>
-              <ControlPoint Id="HB63zbdEOKUNBiQItmQPWQ" Bounds="112,524" Alignment="Bottom" />
-              <ControlPoint Id="TyfQshMRj8aPt6DPL2i97z" Bounds="160,430" Alignment="Top" />
+              <ControlPoint Id="HB63zbdEOKUNBiQItmQPWQ" Bounds="100,732" Alignment="Bottom" />
+              <ControlPoint Id="TyfQshMRj8aPt6DPL2i97z" Bounds="148,638" Alignment="Top" />
             </Node>
-            <ControlPoint Id="KWtqXl40sv1K98Lc7doBu4" Bounds="160,413" />
-            <Node Bounds="428,343,146,19" Id="S1Z7BA47BkkLLAT7yUKXL6">
+            <ControlPoint Id="KWtqXl40sv1K98Lc7doBu4" Bounds="148,621" />
+            <Node Bounds="416,626,146,19" Id="S1Z7BA47BkkLLAT7yUKXL6">
               <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="SetNotifyIconBalloonSettings" />
@@ -3035,20 +3035,21 @@
               <Pin Id="P1QQrnXkLgoNNPjlraEPbY" Name="Tip Icon" Kind="InputPin" />
               <Pin Id="ONFlSRZK5eEQP0iSOxD7Kn" Name="Show Balloon Tip" Kind="InputPin" />
             </Node>
-            <Node Bounds="233,343,139,19" Id="JUv49WWQS4JONg1StheAPo">
+            <Node Bounds="221,626,139,19" Id="JUv49WWQS4JONg1StheAPo">
               <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="SetNotifyIconIconOrDefault" />
               </p:NodeReference>
               <Pin Id="UgCuh1f97j9LfF7yzLpHCi" Name="Input" Kind="InputPin" />
-              <Pin Id="IR8WEENtRIoN38qxB6nMXk" Name="Icon" Kind="InputPin" />
+              <Pin Id="HAQwEkzlZiaN7LFIT7SoL3" Name="Form" Kind="InputPin" />
+              <Pin Id="IR8WEENtRIoN38qxB6nMXk" Name="Custom Icon" Kind="InputPin" />
             </Node>
-            <ControlPoint Id="MVhCk4U5CLkMmUwAhNDEf3" Bounds="466,225" />
-            <ControlPoint Id="JUqN5j3z2ZwQbCoSjHVooJ" Bounds="501,245" />
-            <ControlPoint Id="RnDGWPheNNtOoqj4cZpwOa" Bounds="536,263" />
-            <ControlPoint Id="CKDQPIhsAHeOT8MrxGai2Q" Bounds="571,279" />
-            <ControlPoint Id="EI9rYLxxtgvMuFwhm249Ek" Bounds="369,231" />
-            <Node Bounds="850,343,129,19" Id="PIMbYezD5vvMg9WlzK5QQY">
+            <ControlPoint Id="MVhCk4U5CLkMmUwAhNDEf3" Bounds="454,508" />
+            <ControlPoint Id="JUqN5j3z2ZwQbCoSjHVooJ" Bounds="489,528" />
+            <ControlPoint Id="RnDGWPheNNtOoqj4cZpwOa" Bounds="524,546" />
+            <ControlPoint Id="CKDQPIhsAHeOT8MrxGai2Q" Bounds="559,564" />
+            <ControlPoint Id="EI9rYLxxtgvMuFwhm249Ek" Bounds="357,514" />
+            <Node Bounds="838,626,129,19" Id="PIMbYezD5vvMg9WlzK5QQY">
               <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="GetNotifyIconClickEvents" />
@@ -3060,12 +3061,12 @@
               <Pin Id="DLIoa3mJyX0PxCctWeBcxl" Name="On Mouse Down" Kind="OutputPin" />
               <Pin Id="Q9p3xLGZ1rOK9VXpMDe32D" Name="On Mouse Up" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="FTuIfPF5EoYL1Dj4iCi7nM" Bounds="852,471" />
-            <ControlPoint Id="SIODnmGHjxvPl5n9nIvTqR" Bounds="883,455" />
-            <ControlPoint Id="QNoT9qo5G1gPPIZgx09Cyb" Bounds="914,437" />
-            <ControlPoint Id="QDXs9hrGwH8Lqm8kI5CpiA" Bounds="945,423" />
-            <ControlPoint Id="Fma6Vc5v4KkO88yDpNlJsq" Bounds="976,408" />
-            <Node Bounds="643,343,123,19" Id="QOhg9ZoGvVBMaoAoE6NjGe">
+            <ControlPoint Id="FTuIfPF5EoYL1Dj4iCi7nM" Bounds="840,754" />
+            <ControlPoint Id="SIODnmGHjxvPl5n9nIvTqR" Bounds="871,738" />
+            <ControlPoint Id="QNoT9qo5G1gPPIZgx09Cyb" Bounds="902,720" />
+            <ControlPoint Id="QDXs9hrGwH8Lqm8kI5CpiA" Bounds="933,706" />
+            <ControlPoint Id="Fma6Vc5v4KkO88yDpNlJsq" Bounds="964,691" />
+            <Node Bounds="631,626,123,19" Id="QOhg9ZoGvVBMaoAoE6NjGe">
               <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="NotifyIconContextMenu" />
@@ -3074,9 +3075,19 @@
               <Pin Id="D1bqagXOw57PABrGt9cEQh" Name="Context Menu Items" Kind="InputPin" />
               <Pin Id="UA9RK1FzsznPwM4QDGnfHl" Name="On Context Menu Items Click" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="BDsu1dXri96LoOHRN9G9PH" Bounds="763,289" />
-            <ControlPoint Id="LcnsLfRTdKMLOMnbhIdnX8" Bounds="645,411" />
-            <ControlPoint Id="JNyXmseqCZlNxnIbl2ABdI" Bounds="225,149" />
+            <ControlPoint Id="BDsu1dXri96LoOHRN9G9PH" Bounds="751,572" />
+            <ControlPoint Id="LcnsLfRTdKMLOMnbhIdnX8" Bounds="633,694" />
+            <ControlPoint Id="JNyXmseqCZlNxnIbl2ABdI" Bounds="213,342" />
+            <Node Bounds="121,319,58,26" Id="IuzsK6LQYzhQDIrDEl8ast">
+              <p:NodeReference LastCategoryFullName="Primitive.IDisposable" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="Dispose" />
+                <CategoryReference Kind="MutableInterfaceType" Name="IDisposable" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="TX4qwNrjFRdLLwp6YehCye" Name="Input" Kind="StateInputPin" />
+              <Pin Id="I5X8LmpyacSNP4v1OdZ0m9" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <ControlPoint Id="UnlCKwiXPIzQLjwhHBZwEG" Bounds="290,610" />
           </Canvas>
           <Patch Id="OXjzuxaMT1ELrikgHAEEfu" Name="Create" ParticipatingElements="FioSD0FGu6gNhYtXVgIrn0" />
           <Patch Id="SvLvtTMbcKnP5oz23C61Be" Name="Update" ManuallySortedPins="true">
@@ -3086,7 +3097,7 @@
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="CfOEGZyz8KKNojx2SryHDR" Name="On Mouse Click" Kind="OutputPin" Bounds="238,619" Visibility="Optional" Summary="Fires when the notify icon is clicked" />
-            <Pin Id="VIKnINEkgXzMLp1nSxjcsH" Name="On Double Click" Kind="OutputPin" Bounds="267,606" Visibility="Optional" Summary="Fires when the notify icon is double-clicked" />
+            <Pin Id="VIKnINEkgXzMLp1nSxjcsH" Name="On Double Click" Kind="OutputPin" Bounds="267,606" Summary="Fires when the notify icon is double-clicked" />
             <Pin Id="MC0DteuHyPzNXaXQlTvMsb" Name="On Mouse Move" Kind="OutputPin" Bounds="302,626" Visibility="Optional" Summary="Fires when the mouse moves ove the notify icon" />
             <Pin Id="RqqWl2GInZBMI2kr1Gto5Q" Name="On Mouse Down" Kind="OutputPin" Bounds="327,603" Visibility="Optional" Summary="Fires when the mouse is down on the notify icon" />
             <Pin Id="VOoTkLm6vgjNwpkvbGNRER" Name="On Mouse Up" Kind="OutputPin" Bounds="364,589" Visibility="Optional" Summary="Fires when the mouse is up on the notify icon" />
@@ -3096,12 +3107,12 @@
                 <Choice Kind="TypeFlag" Name="Form" />
               </p:TypeAnnotation>
             </Pin>
-            <Pin Id="IZOiD7rdS05N0dzo0IrGtJ" Name="Show When Minimized" Kind="InputPin" DefaultValue="True" Summary="If true, the system tray icon will show up when the renderer is minimized">
+            <Pin Id="IZOiD7rdS05N0dzo0IrGtJ" Name="Show When Minimized" Kind="InputPin" DefaultValue="True" Visibility="Optional" Summary="If true, the system tray icon will show up when the renderer is minimized. This is the default behavior.">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pin>
-            <Pin Id="VvsRpLx26nnMwm6So4WUkO" Name="Show Notify Icon" Kind="InputPin" Bounds="429,183" DefaultValue="False" Visibility="Optional" Summary="Forces the display of the system tray icon">
+            <Pin Id="VvsRpLx26nnMwm6So4WUkO" Name="Force Show Notify Icon" Kind="InputPin" Bounds="429,183" DefaultValue="False" Visibility="Optional" Summary="Forces the display of the system tray icon, event if the renderer is visible.">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
@@ -3111,12 +3122,12 @@
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pin>
-            <Pin Id="F9Ryaws2TrGPCejALcXaJG" Name="Tip Title" Kind="InputPin" Bounds="296,382" Visibility="Optional" Summary="The title of the balloon attached to the notify icon" />
-            <Pin Id="HGQK2BC2uPdODjXOp0SKlG" Name="Tip Text" Kind="InputPin" Bounds="329,402" Visibility="Optional" Summary="The text of the balloon attached to the notify icon" />
-            <Pin Id="EB6C3Jd2l1aNZqdCAiLNHK" Name="Tip Icon" Kind="InputPin" Bounds="349,429" Visibility="Optional" Summary="The icon of the balloon attached to the notify icon" />
-            <Pin Id="BUfifQmuFnOPh4vFAA7jWF" Name="Show Balloon Tip" Kind="InputPin" Bounds="415,439" Visibility="Optional" Summary="When banged, shows a notification balloon next to your notify icon" />
-            <Pin Id="UGUlHGfGAMdNlMxI7xJVvM" Name="Icon" Kind="InputPin" Bounds="343,298" Visibility="Optional" Summary="A custom icon for your notify icon" />
-            <Pin Id="Sx4dptkgIkPLF8nncdOI7K" Name="Context Menu Items" Kind="InputPin" Bounds="792,268" Summary="A list of strings that will make up the context menu attached to the notify icon" />
+            <Pin Id="F9Ryaws2TrGPCejALcXaJG" Name="Balloon Notification Title" Kind="InputPin" Bounds="296,382" Visibility="Optional" Summary="The title of the balloon attached to the notify icon" />
+            <Pin Id="HGQK2BC2uPdODjXOp0SKlG" Name="Balloon Notification Text" Kind="InputPin" Bounds="329,402" Visibility="Optional" Summary="The text of the balloon attached to the notify icon" />
+            <Pin Id="EB6C3Jd2l1aNZqdCAiLNHK" Name="Balloon Notification Icon" Kind="InputPin" Bounds="349,429" Visibility="Optional" Summary="The icon of the balloon attached to the notify icon" />
+            <Pin Id="BUfifQmuFnOPh4vFAA7jWF" Name="Show Balloon Notification" Kind="InputPin" Bounds="415,439" Visibility="Optional" Summary="When banged, shows a notification balloon next to your notify icon" />
+            <Pin Id="UGUlHGfGAMdNlMxI7xJVvM" Name="Custom Icon" Kind="InputPin" Bounds="343,298" Visibility="Optional" Summary="A custom icon for your notify icon. Can be any classic image or ico file." />
+            <Pin Id="Sx4dptkgIkPLF8nncdOI7K" Name="Context Menu Items" Kind="InputPin" Bounds="792,268" Summary="A list of strings that will make up the context menu attached to the notify icon. This menu is revealed by right-clicking the tray icon." />
           </Patch>
           <ProcessDefinition Id="PKodpYuXDFdPltE5YXbGQT">
             <Fragment Id="NgTGHxlTfasNlZoiWJKotm" Patch="OXjzuxaMT1ELrikgHAEEfu" Enabled="true" />
@@ -3131,7 +3142,6 @@
           <Link Id="CDwxRVOMnteNxoepJyaMS8" Ids="LO3EEWLRPv6M0oqyQgGh93,SYYRreeTPiBOKp96R1hrXz" />
           <Link Id="UEfwsj480yiQdD8Y8twEI2" Ids="F44Od8e6KaEL0iusVzCVAp,V0Dr2y22VzsLQbw5UZIRHy" />
           <Link Id="RaoqaAt1ZuUONFZQtk6mlY" Ids="VvsRpLx26nnMwm6So4WUkO,U0UAfXWIeLkPyvSZ2xkRLV" IsHidden="true" />
-          <Link Id="CvJphFRw1oWMiP48mVjLmu" Ids="P92G6CBzwcFPvAt7jeCM93,FEtbHipqoN8OCxhHeJlYow" />
           <Link Id="GwpJnkK8nRMNUEVMT5FX4x" Ids="I6JWuglCFSRMwWbOdRpYrj,Q3ZvUBY5sGOMK4AQ4DoRKS" />
           <Link Id="OfDltWDCRMANuRx4bexjNV" Ids="QFLdDnx7Oi1L3CUeitj8Ep,OFH9LKKOMkuNLsUigv50Z2" />
           <Link Id="VcuJBjCK7VaOiGNpVXJJ9y" Ids="KvfsZFF41mWLgGpMJJboQ2,HB63zbdEOKUNBiQItmQPWQ" />
@@ -3170,6 +3180,11 @@
           <Link Id="GoKzP0jNK4ALtxYrvMxNlS" Ids="LcnsLfRTdKMLOMnbhIdnX8,TJfZCGDLFdZL6E4zywYf3k" IsHidden="true" />
           <Link Id="VspLv3fhRwbLsWZmoadlyR" Ids="JNyXmseqCZlNxnIbl2ABdI,HvzdTeBTs4PQHFu3DTMdAJ" IsHidden="true" />
           <Link Id="ECjMThppbYgQCjuiTLGpDn" Ids="FKsTvJSEOgoPEMLVjcpv79,JNyXmseqCZlNxnIbl2ABdI" />
+          <Patch Id="QnrCUfBoufWPWlhmsieSWH" Name="Dispose" ParticipatingElements="IuzsK6LQYzhQDIrDEl8ast" />
+          <Link Id="Ln73lfYAjzBOqzZSVtmsje" Ids="QFLdDnx7Oi1L3CUeitj8Ep,TX4qwNrjFRdLLwp6YehCye" />
+          <Link Id="QIEMPFFBIkOONvuXzkO9mK" Ids="UnlCKwiXPIzQLjwhHBZwEG,HAQwEkzlZiaN7LFIT7SoL3" />
+          <Link Id="HOqHr9WoEvSPaZ4qKGM0sB" Ids="NHwewLo8IMBN3gURggo7yu,UnlCKwiXPIzQLjwhHBZwEG" IsHidden="true" />
+          <Link Id="Dy1yteJXB9tLFmT42uYnoT" Ids="P92G6CBzwcFPvAt7jeCM93,FEtbHipqoN8OCxhHeJlYow" />
         </Patch>
       </Node>
       <!--
@@ -3308,115 +3323,144 @@
         </p:NodeReference>
         <Patch Id="CYnH6O97XPKOIOz3KM9VrC">
           <Canvas Id="VBdW80CfBPAMofjTCEoOHk" CanvasType="Group">
-            <ControlPoint Id="MIiolSZJoSJOeKHGLzMaDT" Bounds="361,251" />
-            <Node Bounds="323,282,238,326" Id="RyqSsFqSUfAMfwxvaYzQ2D">
+            <ControlPoint Id="L5Bxq6tG0AfQIXbjfLJZFI" Bounds="348,517" />
+            <ControlPoint Id="Nqn5oZ6cjjiLgjlVTLL1DG" Bounds="445,244" />
+            <Node Bounds="443,302,35,26" Id="I6vwvt5CVBXNS6c0HZbVbe">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="Icon" />
+                <CategoryReference Kind="AssemblyCategory" Name="Form" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="I5hRnShoJJpNXNAag9cOj0" Name="Input" Kind="StateInputPin" />
+              <Pin Id="D0n6b7GDAwCMiAm6dI48tn" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="CLm3iWmUXDzMHiGEjIUsZR" Name="Icon" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="BUeLQ9rdbh4OseN7UG1RVt" Bounds="578,244" />
+            <Pad Id="VWB1HBs3AZRLFhuCbzd9fe" Bounds="279,244,145,114" ShowValueBox="true" isIOBox="true" Value="We prefer to use the form's icon. If the user has set one, it will be retrieved, otherwise, gamma's icon will be used.">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+              <p:ValueBoxSettings>
+                <p:fontsize p:Type="Int32">9</p:fontsize>
+                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+              </p:ValueBoxSettings>
+            </Pad>
+            <Node Bounds="411,358,258,300" Id="KYU6fvx3m7uLbjaZX2iO27">
               <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ProcessStatefulRegion" Name="Cache" />
-                <FullNameCategoryReference ID="Primitive" />
+                <CategoryReference Kind="Category" Name="Primitive" />
               </p:NodeReference>
-              <Pin Id="RtRaG6Vkmd4OlR6O6YNIwB" Name="Force" Kind="InputPin" />
-              <Pin Id="OjzHNb600MzNC0Jrv2eleI" Name="Dispose Cached Outputs" Kind="InputPin" />
-              <Pin Id="OqsKZDNy7iGP7NCogqscJv" Name="Has Changed" Kind="OutputPin" />
-              <Patch Id="BkbGZEeLzdrMkUDoLy2mLa" ManuallySortedPins="true">
-                <Patch Id="AeroT1MrfFSLtefuvTs11u" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="NU8HuWuf4mEOyCMbnrhrit" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="335,562,26,26" Id="GqmWUx2DhjfNIigrcQGiOK">
+              <Pin Id="CjXXq2ceUH8QR3Uebs8mt5" Name="Force" Kind="InputPin" />
+              <Pin Id="HVKH7h3UYUeOLiDkcG8rkC" Name="Dispose Cached Outputs" Kind="InputPin" />
+              <Pin Id="OGkSEboZzyIOynqcV8ATzb" Name="Has Changed" Kind="OutputPin" />
+              <Patch Id="PUWO97v3qGQPz8jdDoxP0d" ManuallySortedPins="true">
+                <Patch Id="RWmhktR8qvsQQzpvzqu0sW" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="Uq1vMiKZm4PMA0B5Zbuj6p" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="423,611,53,26" Id="FS1amv1Ak9JQOXqlRGLWzP">
                   <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
                     <Choice Kind="OperationCallFlag" Name="SetIcon" />
                   </p:NodeReference>
-                  <Pin Id="PF8yJSuQ2pdLPDsVCBoTlE" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="C5g9Fyayx9rO4HKI0MynPQ" Name="Value" Kind="InputPin" />
-                  <Pin Id="MWJvY75grxPOTafi5ofxk0" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="H0IRRdcYhjuMvkVUU2d2f0" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="HqKOKTilfsPPEU28UCfbRs" Name="Value" Kind="InputPin" />
+                  <Pin Id="UREZPoNZk3dQA52mnwAWNR" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="359,342,25,19" Id="A3Ljw1HuDquQSdm50Kblzv">
-                  <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="=" />
-                  </p:NodeReference>
-                  <Pin Id="M4SZBJkb4aRLOlcBTNeW1m" Name="Input" Kind="InputPin" />
-                  <Pin Id="EqyI3m14TzULEFDvHOCqrF" Name="Input 2" Kind="InputPin" />
-                  <Pin Id="IlIBMKfGMpqPhBzkr5PTnZ" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="379,311,40,19" Id="AGRgM3LGhyLN5jpY3Nu6th">
-                  <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="NULL" />
-                  </p:NodeReference>
-                  <Pin Id="VSLkjgmVhukNf46t1rfcp5" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="359,374,190,150" Id="GlL4U7U3pa1QBZnSyhLwPk">
+                <Node Bounds="459,520,98,77" Id="TmrNfR7JYu5P7PpACcv0im">
                   <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:NodeReference>
-                  <Pin Id="Lc3BBmhYerQLvndgFQFxzo" Name="Condition" Kind="InputPin" />
-                  <Patch Id="KLy5NYRzMs7PLMfOojMSv9" ManuallySortedPins="true">
-                    <Patch Id="AA0vls3amogQchLIlBbgf2" Name="Create" ManuallySortedPins="true" />
-                    <Patch Id="IMJ7906FPaCLJI9rpaNaUw" Name="Then" ManuallySortedPins="true" />
-                    <Node Bounds="421,483,116,19" Id="VnQRwo78HcVLqrESOE1q7q">
-                      <p:NodeReference LastCategoryFullName="System.Drawing.Icon" LastSymbolSource="System.Drawing.dll">
+                  <Pin Id="M2upBMwiFhDM8Y1aWyiJzl" Name="Condition" Kind="InputPin" />
+                  <Patch Id="Opu8U7fmzp1OKPy98e38Ur" ManuallySortedPins="true">
+                    <Patch Id="DZh8OI1kxojO46J62r8uxr" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="LYoGCtwPZSmNTA450CFOTm" Name="Then" ManuallySortedPins="true" />
+                    <Node Bounds="471,551,74,19" Id="Ru6h3QLTxRRNzfQ5Kcjedq">
+                      <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="ExtractAssociatedIcon" />
+                        <Choice Kind="ProcessAppFlag" Name="IconFromFile" />
                       </p:NodeReference>
-                      <Pin Id="RpcNbrx3vqvOVWYzW9sRyW" Name="File Path" Kind="InputPin" />
-                      <Pin Id="UZiKQHjIUo0PTb4pJQ22WD" Name="Result" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="371,439,55,26" Id="EjiuKlqU4KXPSJ5xnuloQ4">
-                      <p:NodeReference LastCategoryFullName="System.Reflection.Assembly" LastSymbolSource="System.Reflection.dll">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="Location" />
-                        <CategoryReference Kind="AssemblyCategory" Name="Assembly" NeedsToBeDirectParent="true" />
-                      </p:NodeReference>
-                      <Pin Id="CH8Q0Do9iKVLJQCvF4A6NN" Name="Input" Kind="StateInputPin" />
-                      <Pin Id="AiXnuwCARknLglctOa5ihS" Name="Output" Kind="StateOutputPin" />
-                      <Pin Id="N7PuPqKx4cHNNViVHeh8sz" Name="Location" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="371,404,98,19" Id="AYAPn1vZOqdLCFJd8Tl4u7">
-                      <p:NodeReference LastCategoryFullName="System.Reflection.Assembly" LastSymbolSource="System.Reflection.dll">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="GetEntryAssembly" />
-                      </p:NodeReference>
-                      <Pin Id="LERO1lwDWq8QTPgGJzUE1V" Name="Result" Kind="OutputPin" />
+                      <Pin Id="Mkrmoidu47DMEp6KmKKqFd" Name="Path" Kind="InputPin" />
+                      <Pin Id="RQdF5AgKsyOMU8wTTRILlv" Name="Output" Kind="OutputPin" />
                     </Node>
                   </Patch>
-                  <ControlPoint Id="CkxgiaGEczCPueHbRL1xIj" Bounds="423,518" Alignment="Bottom" />
-                  <ControlPoint Id="EFA044nlyRSPl1J0tGZHQO" Bounds="480,380" Alignment="Top" />
+                  <ControlPoint Id="R6S0LMnu3uCNtQ8z0E3DjN" Bounds="474,527" Alignment="Top" />
+                  <ControlPoint Id="LkHz36CuvHoNgsaOk9GXdp" Bounds="473,592" Alignment="Bottom" />
+                </Node>
+                <Node Bounds="576,399,55,19" Id="OQQeb02P0BTMk2zGI0yD1b">
+                  <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="ToString" />
+                  </p:NodeReference>
+                  <Pin Id="Q2d99l2TDJfOr4g4J9A3VQ" Name="Input" Kind="InputPin" />
+                  <Pin Id="B5gG38jKraoMNcxxlwrnUw" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="576,431,81,19" Id="CMYZyO445WLNIp2j9QYBwq">
+                  <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsNullOrEmpty" />
+                  </p:NodeReference>
+                  <Pin Id="Aj6h2lxqn4DLYCJOo6XDNX" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="I5qHNL5ZRL2OH9uM3ju58h" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="576,463,37,19" Id="Crpm4SxTEEMMY4ouNqRw3e">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="NOT" />
+                  </p:NodeReference>
+                  <Pin Id="Pk0Cujfb9VIMMyDthvaL4c" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="S0iHmyRGzgfK9hlVYc390G" Name="Output" Kind="StateOutputPin" />
                 </Node>
               </Patch>
-              <ControlPoint Id="N9MjHxQqCBxMmvvGUkDLYG" Bounds="361,288" Alignment="Top" />
+              <ControlPoint Id="JWPyjFQs0XhOD38QotEv59" Bounds="475,364" Name="Form Icon" Alignment="Top" />
+              <ControlPoint Id="U0ujd5aMXtfP3UTusTlbjv" Bounds="578,364" Alignment="Top" />
             </Node>
-            <ControlPoint Id="L5Bxq6tG0AfQIXbjfLJZFI" Bounds="339,219" />
+            <Pad Id="VFnyUv5jKOlO58RdsohIrL" Bounds="662,244,135,57" ShowValueBox="true" isIOBox="true" Value="We can also set a custom icon for the systray, if we want.">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+              <p:ValueBoxSettings>
+                <p:fontsize p:Type="Int32">9</p:fontsize>
+                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+              </p:ValueBoxSettings>
+            </Pad>
           </Canvas>
           <Patch Id="IjIYsbIDKInQBdX1rVUFNn" Name="Create" />
           <Patch Id="RoFtm744LkBPi7QPLd2Wpn" Name="Update">
-            <Pin Id="SbV9fpUW9K3PWoNLZpGcNP" Name="Icon" Kind="InputPin" Bounds="403,373">
-              <p:TypeAnnotation LastCategoryFullName="System.Drawing" LastSymbolSource="System.Drawing.dll">
-                <Choice Kind="TypeFlag" Name="Icon" />
+            <Pin Id="SbV9fpUW9K3PWoNLZpGcNP" Name="Custom Icon" Kind="InputPin" Bounds="403,373" DefaultValue="">
+              <p:TypeAnnotation>
+                <Choice Kind="TypeFlag" Name="Path" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="D2T3kHr0cluOGJi8NTdnD8" Name="Input" Kind="InputPin" Bounds="339,218" />
+            <Pin Id="Mwq1T1eaVNZP7qqh3PwX6a" Name="Form" Kind="InputPin">
+              <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="TypeFlag" Name="Form" />
+              </p:TypeAnnotation>
+            </Pin>
           </Patch>
           <ProcessDefinition Id="HRl7Pm5tHKcLeDrfwiqikT">
             <Fragment Id="VVq4JsAkyP8LsY3oTKgpxj" Patch="IjIYsbIDKInQBdX1rVUFNn" Enabled="true" />
             <Fragment Id="PqWRafzHf4pLTGN4NFZFJA" Patch="RoFtm744LkBPi7QPLd2Wpn" Enabled="true" />
           </ProcessDefinition>
-          <Link Id="BOB748fwOKuP3tOxjw4PCD" Ids="SbV9fpUW9K3PWoNLZpGcNP,MIiolSZJoSJOeKHGLzMaDT" IsHidden="true" />
-          <Link Id="APBye2PXL6dPAclM4tdGIS" Ids="MIiolSZJoSJOeKHGLzMaDT,N9MjHxQqCBxMmvvGUkDLYG" />
-          <Link Id="QlGVZh6So93QYunTHg0K8N" Ids="VSLkjgmVhukNf46t1rfcp5,EqyI3m14TzULEFDvHOCqrF" />
-          <Link Id="SPHN64REsCoOwSQ9jQkgvb" Ids="N9MjHxQqCBxMmvvGUkDLYG,M4SZBJkb4aRLOlcBTNeW1m" />
-          <Link Id="IkpGFDyNs1uMVq3TRWcQfu" Ids="IlIBMKfGMpqPhBzkr5PTnZ,Lc3BBmhYerQLvndgFQFxzo" />
-          <Link Id="DLOC8IpyOEWMcwdUM6c5zT" Ids="N7PuPqKx4cHNNViVHeh8sz,RpcNbrx3vqvOVWYzW9sRyW" />
-          <Link Id="Uiv9FZFL2T5P5D3OM2TEfF" Ids="LERO1lwDWq8QTPgGJzUE1V,CH8Q0Do9iKVLJQCvF4A6NN" />
-          <Link Id="PRhVa2D1YEpObj8YYC9Ys0" Ids="EFA044nlyRSPl1J0tGZHQO,CkxgiaGEczCPueHbRL1xIj" IsFeedback="true" />
-          <Link Id="Qy1pScEPRXkP3xq3K5RAE6" Ids="UZiKQHjIUo0PTb4pJQ22WD,CkxgiaGEczCPueHbRL1xIj" />
-          <Link Id="GXmCDbQ4npbQcVCmNmuFov" Ids="N9MjHxQqCBxMmvvGUkDLYG,EFA044nlyRSPl1J0tGZHQO" />
-          <Link Id="RubuJxOh5rDQGceseLiroR" Ids="CkxgiaGEczCPueHbRL1xIj,C5g9Fyayx9rO4HKI0MynPQ" />
-          <Link Id="HhD5sjDg12WQOJPfActgf9" Ids="L5Bxq6tG0AfQIXbjfLJZFI,PF8yJSuQ2pdLPDsVCBoTlE" />
           <Link Id="Lute9zjCF2nMdp1PFD9t3K" Ids="D2T3kHr0cluOGJi8NTdnD8,L5Bxq6tG0AfQIXbjfLJZFI" IsHidden="true" />
+          <Link Id="SWg8loDZV7FPAmyPlHrfTT" Ids="Mwq1T1eaVNZP7qqh3PwX6a,Nqn5oZ6cjjiLgjlVTLL1DG" IsHidden="true" />
+          <Link Id="RbPs4tNCgj0L1VDXiLxhRC" Ids="Nqn5oZ6cjjiLgjlVTLL1DG,I5hRnShoJJpNXNAag9cOj0" />
+          <Link Id="MITPSKDk5bGL4qN9uQD2eH" Ids="SbV9fpUW9K3PWoNLZpGcNP,BUeLQ9rdbh4OseN7UG1RVt" IsHidden="true" />
+          <Link Id="QdF9Ur1MnO1O47MqS8cq4g" Ids="LkHz36CuvHoNgsaOk9GXdp,HqKOKTilfsPPEU28UCfbRs" />
+          <Link Id="Rt1EUo3tYYOO7VokQrBf2T" Ids="L5Bxq6tG0AfQIXbjfLJZFI,H0IRRdcYhjuMvkVUU2d2f0" />
+          <Link Id="MmdZQoh6MqoPR80pacEqGs" Ids="R6S0LMnu3uCNtQ8z0E3DjN,LkHz36CuvHoNgsaOk9GXdp" IsFeedback="true" />
+          <Link Id="Px5ylMnIz34PoMSrIopkER" Ids="CLm3iWmUXDzMHiGEjIUsZR,JWPyjFQs0XhOD38QotEv59" />
+          <Link Id="UIaJGJhfpwPOXbuxQgvZYL" Ids="JWPyjFQs0XhOD38QotEv59,R6S0LMnu3uCNtQ8z0E3DjN" />
+          <Link Id="KqUlLKOWDY9PTqWlkvqqb6" Ids="RQdF5AgKsyOMU8wTTRILlv,LkHz36CuvHoNgsaOk9GXdp" />
+          <Link Id="JY5NGBhcAiDOz2506UAAlH" Ids="BUeLQ9rdbh4OseN7UG1RVt,U0ujd5aMXtfP3UTusTlbjv" />
+          <Link Id="Fdnz7Tls8OkPAchJx754ID" Ids="U0ujd5aMXtfP3UTusTlbjv,Q2d99l2TDJfOr4g4J9A3VQ" />
+          <Link Id="I8ygtVlWw7FLRz05bpRB7l" Ids="B5gG38jKraoMNcxxlwrnUw,Aj6h2lxqn4DLYCJOo6XDNX" />
+          <Link Id="BSyzcIMZM0ELqV3ml770Iq" Ids="U0ujd5aMXtfP3UTusTlbjv,Mkrmoidu47DMEp6KmKKqFd" />
+          <Link Id="MsD0HAMnKsxM8Ktikf3U8M" Ids="I5qHNL5ZRL2OH9uM3ju58h,Pk0Cujfb9VIMMyDthvaL4c" />
+          <Link Id="GJXZihJSAJ4P4IaTWHp7Ue" Ids="S0iHmyRGzgfK9hlVYc390G,M2upBMwiFhDM8Y1aWyiJzl" />
         </Patch>
       </Node>
       <!--
@@ -3430,57 +3474,77 @@
         </p:NodeReference>
         <Patch Id="SriUbo46bekOacCD0y3hXO">
           <Canvas Id="FnpraegnCFJPvIeBKEgnuV" CanvasType="Group">
-            <Node Bounds="185,210,100,26" Id="GXlOJC3kTsHNr5QzX3tA0M">
-              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
-                <Choice Kind="OperationCallFlag" Name="MouseDoubleClick" />
+            <ControlPoint Id="CnVIIVYULoqLYzgb6yVEd8" Bounds="95,131" />
+            <ControlPoint Id="A0nA4cezSqIN0zhr5U3FsK" Bounds="187,304" />
+            <ControlPoint Id="U9VCb3vwzl7M3mYYrTEcIM" Bounds="500,304" />
+            <ControlPoint Id="LZlJ6DULT7mQOLCiOTmZNf" Bounds="303,304" />
+            <ControlPoint Id="KlqJy69hVvFMKIrDKhcsQL" Bounds="398,304" />
+            <ControlPoint Id="ORbCIIaMnWcNbXI3CWzOkL" Bounds="95,304" />
+            <Node Bounds="81,172,487,86" Id="RgiRjRbiJBsPpDSOgbyFbw">
+              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                <FullNameCategoryReference ID="Primitive" />
               </p:NodeReference>
-              <Pin Id="DGkv07z6zD7N6c2ZocYkv5" Name="Input" Kind="StateInputPin" />
-              <Pin Id="AIm5U0BfxBrPT1gghAwUXX" Name="Result" Kind="OutputPin" />
+              <Pin Id="Iiru0cr3eBYPZgRVXImxYV" Name="Force" Kind="InputPin" />
+              <Pin Id="QJYEiKDucDXNp3dSO0UvRt" Name="Dispose Cached Outputs" Kind="InputPin" />
+              <Pin Id="NEZq0PBW0QYLt6unTXxvz7" Name="Has Changed" Kind="OutputPin" />
+              <Patch Id="S8uXT0jZ5A1L1INoGBldXT" ManuallySortedPins="true">
+                <Patch Id="DzwxlfbKP0wPQjctgDab63" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="CD1yGPP2yTLMLTbr1q21fw" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="185,210,100,26" Id="GXlOJC3kTsHNr5QzX3tA0M">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                    <Choice Kind="OperationCallFlag" Name="MouseDoubleClick" />
+                  </p:NodeReference>
+                  <Pin Id="DGkv07z6zD7N6c2ZocYkv5" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="AIm5U0BfxBrPT1gghAwUXX" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="93,210,68,26" Id="SDIm5cleM5jLLqtDH7WG9y">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                    <Choice Kind="OperationCallFlag" Name="MouseClick" />
+                  </p:NodeReference>
+                  <Pin Id="JRfUSnUWBdRLXhEkQMTRmt" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="MB25PvxKdfwPE2CUbKjrvh" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="396,210,72,26" Id="ISMm5qfTXrmP4tTgZnV6EZ">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                    <Choice Kind="OperationCallFlag" Name="MouseDown" />
+                  </p:NodeReference>
+                  <Pin Id="L1Phd57i32SMi2a7Nucaml" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="SGFP67yAZlwMBdAjyjO9DP" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="301,210,70,26" Id="M8DRh2HG42bMXMB6B43gGg">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                    <Choice Kind="OperationCallFlag" Name="MouseMove" />
+                  </p:NodeReference>
+                  <Pin Id="PEWdjHCtfj7OZR4z1YihVA" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="Orr0tQlDmqOPWYqpFddqyI" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="498,210,58,26" Id="Sp9txMCBRwHO5VHwHJrBSH">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="MouseUp" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="IdfZf9ZrkcZODNBq1is7jl" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="TRtMDBjTKDyNKLYjtcJTFK" Name="Result" Kind="OutputPin" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="QhBFinl7MB9LQDAntUFnyY" Bounds="95,179" Alignment="Top" />
+              <ControlPoint Id="Rg74vY0dAZpMw4dLd7IV6w" Bounds="95,252" Alignment="Bottom" />
+              <ControlPoint Id="FW8XQfd6MB1PaPAO6XsU0V" Bounds="187,252" Alignment="Bottom" />
+              <ControlPoint Id="VtyoropeFPrNx5qd1zpwr9" Bounds="303,252" Alignment="Bottom" />
+              <ControlPoint Id="JfSIybkkVsSNyb7HarjVhj" Bounds="398,252" Alignment="Bottom" />
+              <ControlPoint Id="OolNBKtYfZtNSceHiurdcN" Bounds="500,252" Alignment="Bottom" />
             </Node>
-            <ControlPoint Id="CnVIIVYULoqLYzgb6yVEd8" Bounds="94,131" />
-            <ControlPoint Id="A0nA4cezSqIN0zhr5U3FsK" Bounds="187,274" />
-            <Node Bounds="93,210,68,26" Id="SDIm5cleM5jLLqtDH7WG9y">
-              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
-                <Choice Kind="OperationCallFlag" Name="MouseClick" />
-              </p:NodeReference>
-              <Pin Id="JRfUSnUWBdRLXhEkQMTRmt" Name="Input" Kind="StateInputPin" />
-              <Pin Id="MB25PvxKdfwPE2CUbKjrvh" Name="Result" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="396,210,72,26" Id="ISMm5qfTXrmP4tTgZnV6EZ">
-              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
-                <Choice Kind="OperationCallFlag" Name="MouseDown" />
-              </p:NodeReference>
-              <Pin Id="L1Phd57i32SMi2a7Nucaml" Name="Input" Kind="StateInputPin" />
-              <Pin Id="SGFP67yAZlwMBdAjyjO9DP" Name="Result" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="301,210,70,26" Id="M8DRh2HG42bMXMB6B43gGg">
-              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
-                <Choice Kind="OperationCallFlag" Name="MouseMove" />
-              </p:NodeReference>
-              <Pin Id="PEWdjHCtfj7OZR4z1YihVA" Name="Input" Kind="StateInputPin" />
-              <Pin Id="Orr0tQlDmqOPWYqpFddqyI" Name="Result" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="498,210,58,26" Id="Sp9txMCBRwHO5VHwHJrBSH">
-              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="MouseUp" />
-                <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" NeedsToBeDirectParent="true" />
-              </p:NodeReference>
-              <Pin Id="IdfZf9ZrkcZODNBq1is7jl" Name="Input" Kind="StateInputPin" />
-              <Pin Id="TRtMDBjTKDyNKLYjtcJTFK" Name="Result" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="U9VCb3vwzl7M3mYYrTEcIM" Bounds="500,274" />
-            <ControlPoint Id="LZlJ6DULT7mQOLCiOTmZNf" Bounds="303,274" />
-            <ControlPoint Id="KlqJy69hVvFMKIrDKhcsQL" Bounds="398,274" />
-            <ControlPoint Id="ORbCIIaMnWcNbXI3CWzOkL" Bounds="95,274" />
           </Canvas>
           <Patch Id="Isf7GHaHHK6L9ZNMyEbAeL" Name="Create" />
           <Patch Id="AmuhAjXMh4LMdjDxKl0BJe" Name="Update">
@@ -3495,22 +3559,28 @@
             <Fragment Id="F3NYFQR6heCNjNYGV7jt0a" Patch="Isf7GHaHHK6L9ZNMyEbAeL" Enabled="true" />
             <Fragment Id="Qw9FuyMlZGUOaTt6aZ62gj" Patch="AmuhAjXMh4LMdjDxKl0BJe" Enabled="true" />
           </ProcessDefinition>
-          <Link Id="Pn73pFGBcFvQZB9gQvnJ2J" Ids="CnVIIVYULoqLYzgb6yVEd8,DGkv07z6zD7N6c2ZocYkv5" />
           <Link Id="Id2ZumC0fQuP0feOCf8gjX" Ids="Vl1SN1zTXTYOye8f8YHJh5,CnVIIVYULoqLYzgb6yVEd8" IsHidden="true" />
-          <Link Id="HQcifArRHiJN7rZLeq62mA" Ids="AIm5U0BfxBrPT1gghAwUXX,A0nA4cezSqIN0zhr5U3FsK" />
           <Link Id="BX6BhFxsq5FQSyoHtvpaGZ" Ids="A0nA4cezSqIN0zhr5U3FsK,BDGFBCpQY3EMbf6KalZ1p7" IsHidden="true" />
-          <Link Id="KOvcUY3xQMyOKmNpQiHTpD" Ids="CnVIIVYULoqLYzgb6yVEd8,JRfUSnUWBdRLXhEkQMTRmt" />
-          <Link Id="O72Ndn4agVjLHBm1lxNh9P" Ids="CnVIIVYULoqLYzgb6yVEd8,L1Phd57i32SMi2a7Nucaml" />
-          <Link Id="EkxwBtVoCCMPBScxQjtwut" Ids="CnVIIVYULoqLYzgb6yVEd8,PEWdjHCtfj7OZR4z1YihVA" />
-          <Link Id="QEz8qu7AFoWMh7qbFxxw0j" Ids="CnVIIVYULoqLYzgb6yVEd8,IdfZf9ZrkcZODNBq1is7jl" />
-          <Link Id="SwzJWQlB7dVOM6lE9KuedS" Ids="TRtMDBjTKDyNKLYjtcJTFK,U9VCb3vwzl7M3mYYrTEcIM" />
           <Link Id="Kdx90n7HQxRQP2gr9j0tsn" Ids="U9VCb3vwzl7M3mYYrTEcIM,PFMmBQhTQusMbxOlqP6amA" IsHidden="true" />
-          <Link Id="Lo36KoU1W5PN6NypBeXup4" Ids="Orr0tQlDmqOPWYqpFddqyI,LZlJ6DULT7mQOLCiOTmZNf" />
           <Link Id="JqIDvVfrXj9NFx2HoaAE1h" Ids="LZlJ6DULT7mQOLCiOTmZNf,EgImtBKqztmPr2IUNSrzo1" IsHidden="true" />
-          <Link Id="Poo7rTXzt5SMUQ6Vcnv3fR" Ids="SGFP67yAZlwMBdAjyjO9DP,KlqJy69hVvFMKIrDKhcsQL" />
           <Link Id="UOiUthdenC1OI7nBxHNyIe" Ids="KlqJy69hVvFMKIrDKhcsQL,AwOH9vm9qqiQMW2lGb2dmm" IsHidden="true" />
-          <Link Id="EJ0hnY48tHDLcslMQaKVKa" Ids="MB25PvxKdfwPE2CUbKjrvh,ORbCIIaMnWcNbXI3CWzOkL" />
           <Link Id="C6hz1tKiIe5OveyMPsdpKl" Ids="ORbCIIaMnWcNbXI3CWzOkL,JQvcfWT7kegQZg9TDfMMCj" IsHidden="true" />
+          <Link Id="Ig9YwL8Mq0DPY4vYIVlffA" Ids="CnVIIVYULoqLYzgb6yVEd8,QhBFinl7MB9LQDAntUFnyY" />
+          <Link Id="FVeToIW9ze7MrJL0hi2dCz" Ids="QhBFinl7MB9LQDAntUFnyY,JRfUSnUWBdRLXhEkQMTRmt" />
+          <Link Id="UFl2JsOIzZQMF80Ys1uU1g" Ids="QhBFinl7MB9LQDAntUFnyY,DGkv07z6zD7N6c2ZocYkv5" />
+          <Link Id="Lem50IYeeDBNS60ThCDWdg" Ids="QhBFinl7MB9LQDAntUFnyY,PEWdjHCtfj7OZR4z1YihVA" />
+          <Link Id="VV1kKg7YpNTQAP08yxOCNb" Ids="QhBFinl7MB9LQDAntUFnyY,L1Phd57i32SMi2a7Nucaml" />
+          <Link Id="Fq9yfchZXWTP5GuZunHPEn" Ids="QhBFinl7MB9LQDAntUFnyY,IdfZf9ZrkcZODNBq1is7jl" />
+          <Link Id="H9rCPldgF2qLCorbVvmSMi" Ids="MB25PvxKdfwPE2CUbKjrvh,Rg74vY0dAZpMw4dLd7IV6w" />
+          <Link Id="QKgECRy13fSLWDWdf6yzNX" Ids="Rg74vY0dAZpMw4dLd7IV6w,ORbCIIaMnWcNbXI3CWzOkL" />
+          <Link Id="Ni9mACuMwZ3LuZCxTIkdzu" Ids="AIm5U0BfxBrPT1gghAwUXX,FW8XQfd6MB1PaPAO6XsU0V" />
+          <Link Id="Ga3gHtB7pBSPWcM1UAYJit" Ids="FW8XQfd6MB1PaPAO6XsU0V,A0nA4cezSqIN0zhr5U3FsK" />
+          <Link Id="Dg4Z28bpf1GPNz3rHVYeQr" Ids="Orr0tQlDmqOPWYqpFddqyI,VtyoropeFPrNx5qd1zpwr9" />
+          <Link Id="RbZ6dVfbbRNMtmzUz2iTzm" Ids="VtyoropeFPrNx5qd1zpwr9,LZlJ6DULT7mQOLCiOTmZNf" />
+          <Link Id="NUw2xL4S6fNMTpc4hUBpBv" Ids="SGFP67yAZlwMBdAjyjO9DP,JfSIybkkVsSNyb7HarjVhj" />
+          <Link Id="UkJUPwMpyypNaSk0pAILCB" Ids="JfSIybkkVsSNyb7HarjVhj,KlqJy69hVvFMKIrDKhcsQL" />
+          <Link Id="NDAfOe08xUTMcfeYR1uchl" Ids="TRtMDBjTKDyNKLYjtcJTFK,OolNBKtYfZtNSceHiurdcN" />
+          <Link Id="ChT1jWSbJeRNHSsDkDBJft" Ids="OolNBKtYfZtNSceHiurdcN,U9VCb3vwzl7M3mYYrTEcIM" />
         </Patch>
       </Node>
       <!--
@@ -3813,6 +3883,155 @@
           <Link Id="PnOJSxnmW0xOmwy6PGJSTm" Ids="JgE9yL4B33DLXQ9wuD0rmp,T75gCpKXXPFP2EQ9lhnkJC" IsHidden="true" />
           <Link Id="RY4LL3h7BwPPjo7QNBhxnH" Ids="M6m0yHWs445O7r7MtdxCtF,Dp2aLEf0xlFMWRJingvFnH" />
           <Link Id="AnKVsW2KHFhNA05ZZCvSCL" Ids="NEYbGDJ7vuLMS6qMcVTmat,M6m0yHWs445O7r7MtdxCtF" IsHidden="true" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ IconFromFile (Internal) ************************
+
+-->
+      <Node Name="IconFromFile (Internal)" Bounds="1100,773" Id="JkWBFyZyLrsOIaAfVs6bhe" Summary="Outputs an Icon from a Path. All standard file formats are supported.">
+        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <Choice Kind="ContainerDefinition" Name="Process" />
+        </p:NodeReference>
+        <Patch Id="KUa9lnNlylFLiuIy85vKPp">
+          <Canvas Id="IERrB5n1I41OaSfkpKg7eK" CanvasType="Group">
+            <Node Bounds="584,277,55,19" Id="RMrbDR3TCupNWjxcIfpRgO">
+              <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="ToString" />
+              </p:NodeReference>
+              <Pin Id="RzDX5e68lcrMtcksEy4Vw4" Name="Input" Kind="InputPin" />
+              <Pin Id="D3HMxjn7QGgMrHWq0lru2a" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="653,280,57,19" Id="RG4SKbNE30JMX7bOOPoyZK">
+              <p:NodeReference LastCategoryFullName="IO.Path" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="Filename (Split)" />
+              </p:NodeReference>
+              <Pin Id="UMXHHixCif9Nf3LReDYsLQ" Name="Input" Kind="StateInputPin" />
+              <Pin Id="BBcgzsc9zq1PvvoyTXqS7t" Name="Directory" Kind="OutputPin" />
+              <Pin Id="S9ooxY7QgieM0L6HhipEWE" Name="Filename" Kind="OutputPin" />
+              <Pin Id="PGf75ZB0sSpMy4cq41fkPG" Name="Extension" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="705,314,25,19" Id="GAAQzerpPv9N1zs15pqlbQ">
+              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="=" />
+              </p:NodeReference>
+              <Pin Id="Cb3jNH2ZNjmP8axm05TH7F" Name="Input" Kind="InputPin" />
+              <Pin Id="CxKNHannsBmNZwiN1seaYf" Name="Input 2" Kind="InputPin" DefaultValue="ico">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="HLmJOHciahLPLXQz4JW19z" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="572,387,72,79" Id="EjeXafhUpx5PDzUDM3xGEE">
+              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                <FullNameCategoryReference ID="Primitive" />
+              </p:NodeReference>
+              <Pin Id="MrGdYJyA45ZLKgiaGbFFkd" Name="Condition" Kind="InputPin" />
+              <Patch Id="NMG10vMX7C1Ob9NjIpeyDw" ManuallySortedPins="true">
+                <Patch Id="JyQyw73LCKXMAqLM6Pd3Jv" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="IurrKbV146WQCgpsWbGl4f" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="586,413,46,26" Id="Ggk4pw4a3SjPNYO0UmlvJJ">
+                  <p:NodeReference LastCategoryFullName="System.Drawing.Icon" LastSymbolSource="System.Drawing.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="Icon" />
+                    <Choice Kind="OperationCallFlag" Name="Create" />
+                    <PinReference Kind="InputPin" Name="File Name" />
+                  </p:NodeReference>
+                  <Pin Id="L4IKJd7t7m7NVH906RbsoC" Name="File Name" Kind="InputPin" />
+                  <Pin Id="FspKFcEhZYdNvDZ0FjHQwd" Name="Output" Kind="StateOutputPin" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="ETCZCwWUgxjOmk5xBMF8uc" Bounds="588,460" Alignment="Bottom" />
+              <ControlPoint Id="FUIxOb85GXHLQZCmKv9YJB" Bounds="586,393" Alignment="Top" />
+            </Node>
+            <Node Bounds="704,439,37,19" Id="FqwExKuY92iPQ0dqvF6cJ8">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="NOT" />
+              </p:NodeReference>
+              <Pin Id="POX10G9Tp4UNTWIxaOM5ET" Name="Input" Kind="StateInputPin" />
+              <Pin Id="NCuecRCmOiGPjk5H59gEMj" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Node Bounds="574,491,165,138" Id="KtQ097MXOySOlMizz2SAjo">
+              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+              </p:NodeReference>
+              <Pin Id="OEmiKJPKmjwLz3ZVOKGdt2" Name="Condition" Kind="InputPin" />
+              <Patch Id="OUBn3UwgkhANnRwxkeuDYv" ManuallySortedPins="true">
+                <Patch Id="E4uECB2B9TING5Kmo0pVUY" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="MMVFO4oynbyOAVgLUZoQSc" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="603,514,46,26" Id="HvsWu981PtyOfp3yT5BLbQ">
+                  <p:NodeReference LastCategoryFullName="System.Drawing.Bitmap" LastSymbolSource="System.Drawing.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="Bitmap" />
+                    <Choice Kind="OperationCallFlag" Name="Create" />
+                    <PinReference Kind="InputPin" Name="Filename" />
+                  </p:NodeReference>
+                  <Pin Id="PmmpMhQh6lVNA2ii2mdaOa" Name="Filename" Kind="InputPin" />
+                  <Pin Id="Ms1Zk2FhJpxPO6ZuRa0nS0" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="603,549,58,26" Id="L6xzHxc3k8KMe7BVe7vvNj">
+                  <p:NodeReference LastCategoryFullName="System.Drawing.Bitmap" LastSymbolSource="System.Drawing.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="GetHicon" />
+                    <CategoryReference Kind="AssemblyCategory" Name="Bitmap" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="FFvFrKRHp46MprDRpoxUe0" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="EB77DCCyB0jPiepYigLnsr" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="HtDvjIqK8PjQL1bc0BrfxX" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="656,583,71,19" Id="NuYohivQiV7N8eIDINwAXy">
+                  <p:NodeReference LastCategoryFullName="System.Drawing.Icon" LastSymbolSource="System.Drawing.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="FromHandle" />
+                    <CategoryReference Kind="AssemblyCategory" Name="Icon" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="HaLn1L3x02YQbjkVtJIvEo" Name="Handle" Kind="InputPin" />
+                  <Pin Id="DrWyrIye1SpNDAZktfWuJV" Name="Result" Kind="OutputPin" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="OqLRa9fegabL4hTruLlT66" Bounds="588,498" Alignment="Top" />
+              <ControlPoint Id="H1OvsboMXLALxHEsF3F2V0" Bounds="658,623" Alignment="Bottom" />
+            </Node>
+            <ControlPoint Id="FnuNEtiQY7hPU4xtke8zM3" Bounds="586,251" />
+            <ControlPoint Id="L267dQsp4uHMfJTtVwi0Jc" Bounds="658,651" />
+          </Canvas>
+          <Patch Id="UUT84G3eqL4PDfCNp6Tc4u" Name="Create" />
+          <Patch Id="H4ri8ZzlCJvPn20aGzqbcc" Name="Update">
+            <Pin Id="I6xyzldMDXcMlOupYzij9S" Name="Path" Kind="InputPin" Bounds="608,245" />
+            <Pin Id="HgQriHX60sSPCXSjAxEYn0" Name="Output" Kind="OutputPin" Bounds="651,660" />
+          </Patch>
+          <ProcessDefinition Id="LMRr2soDLybLZMvgRyCGEG">
+            <Fragment Id="NwdaLsylRgQQLCJPHrEKdv" Patch="UUT84G3eqL4PDfCNp6Tc4u" Enabled="true" />
+            <Fragment Id="L64KcpMxzmsMiLp9SkmTbU" Patch="H4ri8ZzlCJvPn20aGzqbcc" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="SXyoz78aiesPaLSXZGMSQs" Ids="D3HMxjn7QGgMrHWq0lru2a,L4IKJd7t7m7NVH906RbsoC" />
+          <Link Id="TLNwqzfzphtPqohWNIm1Sa" Ids="D3HMxjn7QGgMrHWq0lru2a,PmmpMhQh6lVNA2ii2mdaOa" />
+          <Link Id="LGldg6IdHR6PZreOVcUL65" Ids="PGf75ZB0sSpMy4cq41fkPG,Cb3jNH2ZNjmP8axm05TH7F" />
+          <Link Id="UgxxTPbUC46LuOZinYKYmW" Ids="HLmJOHciahLPLXQz4JW19z,MrGdYJyA45ZLKgiaGbFFkd" />
+          <Link Id="CL2hr71kGMwLkWDwwpSiKT" Ids="HLmJOHciahLPLXQz4JW19z,POX10G9Tp4UNTWIxaOM5ET" />
+          <Link Id="Srw8L4fntVLMaPT3PKSeJF" Ids="FUIxOb85GXHLQZCmKv9YJB,ETCZCwWUgxjOmk5xBMF8uc" IsFeedback="true" />
+          <Link Id="M5Q4Cflkwj5MNNK8DVMErQ" Ids="FspKFcEhZYdNvDZ0FjHQwd,ETCZCwWUgxjOmk5xBMF8uc" />
+          <Link Id="OfUTaguwzdbP1nUcUZzPYW" Ids="OqLRa9fegabL4hTruLlT66,H1OvsboMXLALxHEsF3F2V0" IsFeedback="true" />
+          <Link Id="EMgGowj6VvvMJ80o4j68bh" Ids="ETCZCwWUgxjOmk5xBMF8uc,OqLRa9fegabL4hTruLlT66" />
+          <Link Id="A8DqKq29uYLMbVO0pz21rK" Ids="Ms1Zk2FhJpxPO6ZuRa0nS0,FFvFrKRHp46MprDRpoxUe0" />
+          <Link Id="QnQeFkO3FBLQSdepqeNqCG" Ids="HtDvjIqK8PjQL1bc0BrfxX,HaLn1L3x02YQbjkVtJIvEo" />
+          <Link Id="H2ge5lsH6JEMNuj3pJ5acV" Ids="DrWyrIye1SpNDAZktfWuJV,H1OvsboMXLALxHEsF3F2V0" />
+          <Link Id="TLD80CLjJYALvlsyyqpoir" Ids="NCuecRCmOiGPjk5H59gEMj,OEmiKJPKmjwLz3ZVOKGdt2" />
+          <Link Id="O9pUgUdz5fxOZ8GK5zKBRW" Ids="FnuNEtiQY7hPU4xtke8zM3,UMXHHixCif9Nf3LReDYsLQ" />
+          <Link Id="UvYVysAxBeBNmPE7VIVIxe" Ids="I6xyzldMDXcMlOupYzij9S,FnuNEtiQY7hPU4xtke8zM3" IsHidden="true" />
+          <Link Id="DeHb8IOkiWnM5lFqxI9MMM" Ids="FnuNEtiQY7hPU4xtke8zM3,RzDX5e68lcrMtcksEy4Vw4" />
+          <Link Id="B0ULr2PsxaqNLL7aYzJNzR" Ids="H1OvsboMXLALxHEsF3F2V0,L267dQsp4uHMfJTtVwi0Jc" />
+          <Link Id="Rc2VYv0yruoMgSU46GThXA" Ids="L267dQsp4uHMfJTtVwi0Jc,HgQriHX60sSPCXSjAxEYn0" IsHidden="true" />
         </Patch>
       </Node>
     </Canvas>

--- a/VL.WinFormsUtils.vl
+++ b/VL.WinFormsUtils.vl
@@ -3430,7 +3430,7 @@
           <Patch Id="IjIYsbIDKInQBdX1rVUFNn" Name="Create" />
           <Patch Id="RoFtm744LkBPi7QPLd2Wpn" Name="Update">
             <Pin Id="SbV9fpUW9K3PWoNLZpGcNP" Name="Custom Icon" Kind="InputPin" Bounds="403,373" DefaultValue="">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="IO" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Path" />
               </p:TypeAnnotation>
             </Pin>

--- a/VL.WinFormsUtils.vl
+++ b/VL.WinFormsUtils.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="RvP7sk1m7JJPdhXFZBJ9QH" Credits="domj" LanguageVersion="2020.1.0.53" Version="0.128">
-  <NugetDependency Id="UwfuWerP2euNo6hOREGgsM" Location="VL.CoreLib" Version="2020.1.0" />
+<Document xmlns:p="property" Id="RvP7sk1m7JJPdhXFZBJ9QH" Credits="domj" LanguageVersion="2020.1.2.135" Version="0.128">
+  <NugetDependency Id="UwfuWerP2euNo6hOREGgsM" Location="VL.CoreLib" Version="2020.1.2" />
   <Patch Id="Ma5EOpkdyX0MP988WqaA0S">
     <Canvas Id="RCrnjQgCyFXMq9P9WAm3dl" DefaultCategory="VL.WinFormsUtils" CanvasType="FullCategory">
       <!--
@@ -2923,6 +2923,898 @@
           </Patch>
         </Node>
       </Canvas>
+      <!--
+
+    ************************ NotifyIcon ************************
+
+-->
+      <Node Name="NotifyIcon" Bounds="925,1218" Id="SDbXXM4CizuPrndu6GXmGJ" Summary="Creates a notify icon in the system tray" Remarks="By default, the icon only shows up when the renderer is minimized. To force it, enable the optional Show Notify Icon pin.">
+        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <Choice Kind="ContainerDefinition" Name="Process" />
+        </p:NodeReference>
+        <Patch Id="S3MSkIg2KX8MVm85Cpo7aZ">
+          <Canvas Id="N8j6EYB8TDRMX2j3Q8o79l" CanvasType="Group">
+            <Node Bounds="110,31,53,26" Id="PfaTq1vuroMN5FdOnxaFQY">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                <Choice Kind="OperationCallFlag" Name="Create" />
+              </p:NodeReference>
+              <Pin Id="Ru0SLUzybYrNoYQeOZAZEa" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Pad Id="QFLdDnx7Oi1L3CUeitj8Ep" SlotId="RKdZV3j8OxFMqGtsZTYtPK" Bounds="112,86" />
+            <ControlPoint Id="A7Cf2reAgiRO67htuFIezG" Bounds="225,44" />
+            <Node Bounds="223,82,74,26" Id="BrzParhQGEJLGW6TNYbrgr">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="WindowState" />
+                <CategoryReference Kind="AssemblyCategory" Name="Form" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="VePYybbQO42PWkRt66GRmn" Name="Input" Kind="StateInputPin" />
+              <Pin Id="FKsTvJSEOgoPEMLVjcpv79" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="EAuiAIb1fsbMaFmy5MJSY5" Name="Window State" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="292,120,25,19" Id="FAYgweJLpAkNzh0jLugZjh">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.FormWindowState" LastSymbolSource="System.Windows.Forms.dll">
+                <CategoryReference Kind="AssemblyCategory" Name="FormWindowState" />
+                <Choice Kind="OperationCallFlag" Name="=" />
+              </p:NodeReference>
+              <Pin Id="OHrs9rZO8mqNMj21x4g9t8" Name="Input" Kind="InputPin" />
+              <Pin Id="FpkYtEkqSBUNw1rWcdYpOh" Name="Input 2" Kind="InputPin" DefaultValue="Minimized">
+                <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                  <Choice Kind="TypeFlag" Name="FormWindowState" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="LO3EEWLRPv6M0oqyQgGh93" Name="Result" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="F44Od8e6KaEL0iusVzCVAp" Bounds="326,65" />
+            <Node Bounds="292,153,37,19" Id="AlEmZfRhlqhNo4wNZZVjh8">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="AND" />
+              </p:NodeReference>
+              <Pin Id="SYYRreeTPiBOKp96R1hrXz" Name="Input" Kind="StateInputPin" />
+              <Pin Id="V0Dr2y22VzsLQbw5UZIRHy" Name="Input 2" Kind="InputPin" />
+              <Pin Id="P92G6CBzwcFPvAt7jeCM93" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <ControlPoint Id="U0UAfXWIeLkPyvSZ2xkRLV" Bounds="349,164" />
+            <Node Bounds="292,195,60,19" Id="CCbWthfK88VNnbAt5d1ytw">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="OR" />
+              </p:NodeReference>
+              <Pin Id="FEtbHipqoN8OCxhHeJlYow" Name="Input" Kind="StateInputPin" />
+              <Pin Id="Sne3mzcRCaaOB8ddOLzVAt" Name="Input 2" Kind="InputPin" />
+              <Pin Id="I6JWuglCFSRMwWbOdRpYrj" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Node Bounds="110,242,187,26" Id="N0UjbSpFf3NPArfPa5LGWF">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                <Choice Kind="OperationCallFlag" Name="SetVisible" />
+              </p:NodeReference>
+              <Pin Id="OFH9LKKOMkuNLsUigv50Z2" Name="Input" Kind="StateInputPin" />
+              <Pin Id="Q3ZvUBY5sGOMK4AQ4DoRKS" Name="Value" Kind="InputPin" />
+              <Pin Id="LyeU9D0sVyTMf00M6lYVJq" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Node Bounds="98,423,77,106" Id="EAEVeWDT93vLGMT0Swfgyp">
+              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                <FullNameCategoryReference ID="Primitive" />
+              </p:NodeReference>
+              <Pin Id="Eu5Lfk1GMyWNrfwfwSE4V2" Name="Force" Kind="InputPin" />
+              <Pin Id="GWiDhrr19UbQFlP29jLBx1" Name="Dispose Cached Outputs" Kind="InputPin" />
+              <Pin Id="JLUTIiJev4ZOS8TkeRA7SL" Name="Has Changed" Kind="OutputPin" />
+              <Patch Id="JLUkDOWIkCbL0QghqMO7O9" ManuallySortedPins="true">
+                <Patch Id="FOCKU0gxo4hNXdH9s7GdKa" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="VQg4buXZyP5PxoNKARe667" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="110,461,53,26" Id="DSigSz82AVBM9GgMOVxSP5">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                    <Choice Kind="OperationCallFlag" Name="SetText" />
+                  </p:NodeReference>
+                  <Pin Id="PT1FIDoXmPeMLjrXTh4FMU" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="SvYTrLPZpnqOFpwVvCwZOK" Name="Value" Kind="InputPin" />
+                  <Pin Id="KvfsZFF41mWLgGpMJJboQ2" Name="Output" Kind="StateOutputPin" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="HB63zbdEOKUNBiQItmQPWQ" Bounds="112,524" Alignment="Bottom" />
+              <ControlPoint Id="TyfQshMRj8aPt6DPL2i97z" Bounds="160,430" Alignment="Top" />
+            </Node>
+            <ControlPoint Id="KWtqXl40sv1K98Lc7doBu4" Bounds="160,413" />
+            <Node Bounds="428,343,146,19" Id="S1Z7BA47BkkLLAT7yUKXL6">
+              <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="SetNotifyIconBalloonSettings" />
+              </p:NodeReference>
+              <Pin Id="GW5O7HOd5jOQWxDPcs1PRF" Name="Input" Kind="InputPin" />
+              <Pin Id="EutB2ah0PP8NPOfMMi4BAD" Name="Tip Title" Kind="InputPin" />
+              <Pin Id="IFNjv3aelCmMDkK6UU6CCT" Name="Tip Text" Kind="InputPin" />
+              <Pin Id="P1QQrnXkLgoNNPjlraEPbY" Name="Tip Icon" Kind="InputPin" />
+              <Pin Id="ONFlSRZK5eEQP0iSOxD7Kn" Name="Show Balloon Tip" Kind="InputPin" />
+            </Node>
+            <Node Bounds="233,343,139,19" Id="JUv49WWQS4JONg1StheAPo">
+              <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="SetNotifyIconIconOrDefault" />
+              </p:NodeReference>
+              <Pin Id="UgCuh1f97j9LfF7yzLpHCi" Name="Input" Kind="InputPin" />
+              <Pin Id="IR8WEENtRIoN38qxB6nMXk" Name="Icon" Kind="InputPin" />
+            </Node>
+            <ControlPoint Id="MVhCk4U5CLkMmUwAhNDEf3" Bounds="466,225" />
+            <ControlPoint Id="JUqN5j3z2ZwQbCoSjHVooJ" Bounds="501,245" />
+            <ControlPoint Id="RnDGWPheNNtOoqj4cZpwOa" Bounds="536,263" />
+            <ControlPoint Id="CKDQPIhsAHeOT8MrxGai2Q" Bounds="571,279" />
+            <ControlPoint Id="EI9rYLxxtgvMuFwhm249Ek" Bounds="369,231" />
+            <Node Bounds="850,343,129,19" Id="PIMbYezD5vvMg9WlzK5QQY">
+              <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="GetNotifyIconClickEvents" />
+              </p:NodeReference>
+              <Pin Id="Q3kKy8kUaVqLOc28WSHpBk" Name="Input" Kind="InputPin" />
+              <Pin Id="GkCKaPChz0nOctZkvs83ve" Name="On Mouse Click" Kind="OutputPin" />
+              <Pin Id="Co1oz1E2483Oz0Og4xpafx" Name="On Double Click" Kind="OutputPin" />
+              <Pin Id="HdIxgeNRl8oPAVzj6xhAoC" Name="On Mouse Move" Kind="OutputPin" />
+              <Pin Id="DLIoa3mJyX0PxCctWeBcxl" Name="On Mouse Down" Kind="OutputPin" />
+              <Pin Id="Q9p3xLGZ1rOK9VXpMDe32D" Name="On Mouse Up" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="FTuIfPF5EoYL1Dj4iCi7nM" Bounds="852,471" />
+            <ControlPoint Id="SIODnmGHjxvPl5n9nIvTqR" Bounds="883,455" />
+            <ControlPoint Id="QNoT9qo5G1gPPIZgx09Cyb" Bounds="914,437" />
+            <ControlPoint Id="QDXs9hrGwH8Lqm8kI5CpiA" Bounds="945,423" />
+            <ControlPoint Id="Fma6Vc5v4KkO88yDpNlJsq" Bounds="976,408" />
+            <Node Bounds="643,343,123,19" Id="QOhg9ZoGvVBMaoAoE6NjGe">
+              <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="NotifyIconContextMenu" />
+              </p:NodeReference>
+              <Pin Id="DX6Jbe3rZukNbyXEZhTBl8" Name="Input" Kind="InputPin" />
+              <Pin Id="D1bqagXOw57PABrGt9cEQh" Name="Context Menu Items" Kind="InputPin" />
+              <Pin Id="UA9RK1FzsznPwM4QDGnfHl" Name="On Context Menu Items Click" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="BDsu1dXri96LoOHRN9G9PH" Bounds="763,289" />
+            <ControlPoint Id="LcnsLfRTdKMLOMnbhIdnX8" Bounds="645,411" />
+            <ControlPoint Id="JNyXmseqCZlNxnIbl2ABdI" Bounds="225,149" />
+          </Canvas>
+          <Patch Id="OXjzuxaMT1ELrikgHAEEfu" Name="Create" ParticipatingElements="FioSD0FGu6gNhYtXVgIrn0" />
+          <Patch Id="SvLvtTMbcKnP5oz23C61Be" Name="Update" ManuallySortedPins="true">
+            <Pin Id="HvzdTeBTs4PQHFu3DTMdAJ" Name="Output" Kind="OutputPin" Bounds="184,99" Summary="The renderer's form">
+              <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="TypeFlag" Name="Form" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="CfOEGZyz8KKNojx2SryHDR" Name="On Mouse Click" Kind="OutputPin" Bounds="238,619" Visibility="Optional" Summary="Fires when the notify icon is clicked" />
+            <Pin Id="VIKnINEkgXzMLp1nSxjcsH" Name="On Double Click" Kind="OutputPin" Bounds="267,606" Visibility="Optional" Summary="Fires when the notify icon is double-clicked" />
+            <Pin Id="MC0DteuHyPzNXaXQlTvMsb" Name="On Mouse Move" Kind="OutputPin" Bounds="302,626" Visibility="Optional" Summary="Fires when the mouse moves ove the notify icon" />
+            <Pin Id="RqqWl2GInZBMI2kr1Gto5Q" Name="On Mouse Down" Kind="OutputPin" Bounds="327,603" Visibility="Optional" Summary="Fires when the mouse is down on the notify icon" />
+            <Pin Id="VOoTkLm6vgjNwpkvbGNRER" Name="On Mouse Up" Kind="OutputPin" Bounds="364,589" Visibility="Optional" Summary="Fires when the mouse is up on the notify icon" />
+            <Pin Id="TJfZCGDLFdZL6E4zywYf3k" Name="On Context Menu Items Click" Kind="OutputPin" Bounds="654,441" Summary="A spread of observable that fires when an item of the context menu attached to the notify icon is pressed" />
+            <Pin Id="NHwewLo8IMBN3gURggo7yu" Name="Input" Kind="InputPin" Summary="The renderer your notify icon is attached to">
+              <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="TypeFlag" Name="Form" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="IZOiD7rdS05N0dzo0IrGtJ" Name="Show When Minimized" Kind="InputPin" DefaultValue="True" Summary="If true, the system tray icon will show up when the renderer is minimized">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="VvsRpLx26nnMwm6So4WUkO" Name="Show Notify Icon" Kind="InputPin" Bounds="429,183" DefaultValue="False" Visibility="Optional" Summary="Forces the display of the system tray icon">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="DhnomCDYhQ5QPnixdCjUo9" Name="Text" Kind="InputPin" Bounds="234,743" DefaultValue="Callmenames" Summary="Sets the text of the tooltip that shows up when you hover the notify icon">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="F9Ryaws2TrGPCejALcXaJG" Name="Tip Title" Kind="InputPin" Bounds="296,382" Visibility="Optional" Summary="The title of the balloon attached to the notify icon" />
+            <Pin Id="HGQK2BC2uPdODjXOp0SKlG" Name="Tip Text" Kind="InputPin" Bounds="329,402" Visibility="Optional" Summary="The text of the balloon attached to the notify icon" />
+            <Pin Id="EB6C3Jd2l1aNZqdCAiLNHK" Name="Tip Icon" Kind="InputPin" Bounds="349,429" Visibility="Optional" Summary="The icon of the balloon attached to the notify icon" />
+            <Pin Id="BUfifQmuFnOPh4vFAA7jWF" Name="Show Balloon Tip" Kind="InputPin" Bounds="415,439" Visibility="Optional" Summary="When banged, shows a notification balloon next to your notify icon" />
+            <Pin Id="UGUlHGfGAMdNlMxI7xJVvM" Name="Icon" Kind="InputPin" Bounds="343,298" Visibility="Optional" Summary="A custom icon for your notify icon" />
+            <Pin Id="Sx4dptkgIkPLF8nncdOI7K" Name="Context Menu Items" Kind="InputPin" Bounds="792,268" Summary="A list of strings that will make up the context menu attached to the notify icon" />
+          </Patch>
+          <ProcessDefinition Id="PKodpYuXDFdPltE5YXbGQT">
+            <Fragment Id="NgTGHxlTfasNlZoiWJKotm" Patch="OXjzuxaMT1ELrikgHAEEfu" Enabled="true" />
+            <Fragment Id="Crdc8nqFlpzNWIAVXf4THU" Patch="SvLvtTMbcKnP5oz23C61Be" Enabled="true" />
+          </ProcessDefinition>
+          <Slot Id="RKdZV3j8OxFMqGtsZTYtPK" Name="Notify Icon" />
+          <Link Id="FioSD0FGu6gNhYtXVgIrn0" Ids="Ru0SLUzybYrNoYQeOZAZEa,QFLdDnx7Oi1L3CUeitj8Ep" />
+          <Link Id="AmMt4RPGd4jQO3Og4aGEz1" Ids="NHwewLo8IMBN3gURggo7yu,A7Cf2reAgiRO67htuFIezG" IsHidden="true" />
+          <Link Id="AQ6z0CTcF0HMlacXJFu53f" Ids="A7Cf2reAgiRO67htuFIezG,VePYybbQO42PWkRt66GRmn" />
+          <Link Id="BOAm58mcbrxMp6XDRLlT2m" Ids="EAuiAIb1fsbMaFmy5MJSY5,OHrs9rZO8mqNMj21x4g9t8" />
+          <Link Id="I9DeCaF8j57NTk8DuJquY2" Ids="IZOiD7rdS05N0dzo0IrGtJ,F44Od8e6KaEL0iusVzCVAp" IsHidden="true" />
+          <Link Id="CDwxRVOMnteNxoepJyaMS8" Ids="LO3EEWLRPv6M0oqyQgGh93,SYYRreeTPiBOKp96R1hrXz" />
+          <Link Id="UEfwsj480yiQdD8Y8twEI2" Ids="F44Od8e6KaEL0iusVzCVAp,V0Dr2y22VzsLQbw5UZIRHy" />
+          <Link Id="RaoqaAt1ZuUONFZQtk6mlY" Ids="VvsRpLx26nnMwm6So4WUkO,U0UAfXWIeLkPyvSZ2xkRLV" IsHidden="true" />
+          <Link Id="CvJphFRw1oWMiP48mVjLmu" Ids="P92G6CBzwcFPvAt7jeCM93,FEtbHipqoN8OCxhHeJlYow" />
+          <Link Id="GwpJnkK8nRMNUEVMT5FX4x" Ids="I6JWuglCFSRMwWbOdRpYrj,Q3ZvUBY5sGOMK4AQ4DoRKS" />
+          <Link Id="OfDltWDCRMANuRx4bexjNV" Ids="QFLdDnx7Oi1L3CUeitj8Ep,OFH9LKKOMkuNLsUigv50Z2" />
+          <Link Id="VcuJBjCK7VaOiGNpVXJJ9y" Ids="KvfsZFF41mWLgGpMJJboQ2,HB63zbdEOKUNBiQItmQPWQ" />
+          <Link Id="RnlRZsJhehCMPugdwUg338" Ids="TyfQshMRj8aPt6DPL2i97z,SvYTrLPZpnqOFpwVvCwZOK" />
+          <Link Id="Vh3pNUDGBMbLTsvuVCVTBn" Ids="KWtqXl40sv1K98Lc7doBu4,TyfQshMRj8aPt6DPL2i97z" />
+          <Link Id="PcOZVYBmMB1LguTVYX8Tfh" Ids="DhnomCDYhQ5QPnixdCjUo9,KWtqXl40sv1K98Lc7doBu4" IsHidden="true" />
+          <Link Id="A3Q05afnp1ZLRe4cICnprN" Ids="LyeU9D0sVyTMf00M6lYVJq,PT1FIDoXmPeMLjrXTh4FMU" />
+          <Link Id="CEiklHoccsoPzLQYxfRJ3M" Ids="LyeU9D0sVyTMf00M6lYVJq,GW5O7HOd5jOQWxDPcs1PRF" />
+          <Link Id="OsqN8ElUViHNOaBBs4Iahg" Ids="LyeU9D0sVyTMf00M6lYVJq,UgCuh1f97j9LfF7yzLpHCi" />
+          <Link Id="ShDAYbvhiNMNiI5inGaPNy" Ids="MVhCk4U5CLkMmUwAhNDEf3,EutB2ah0PP8NPOfMMi4BAD" />
+          <Link Id="AhNdCBDvgZfLK0nhtx2CcA" Ids="F9Ryaws2TrGPCejALcXaJG,MVhCk4U5CLkMmUwAhNDEf3" IsHidden="true" />
+          <Link Id="ODd67suMTFJPauNEG4P9bd" Ids="JUqN5j3z2ZwQbCoSjHVooJ,IFNjv3aelCmMDkK6UU6CCT" />
+          <Link Id="RJE2bRAOxmcMO1em7Ag94i" Ids="HGQK2BC2uPdODjXOp0SKlG,JUqN5j3z2ZwQbCoSjHVooJ" IsHidden="true" />
+          <Link Id="TywxzjVWRvcMpPEazyVrkW" Ids="RnDGWPheNNtOoqj4cZpwOa,P1QQrnXkLgoNNPjlraEPbY" />
+          <Link Id="AVjSMhPVoe5PaEEkGy45w7" Ids="EB6C3Jd2l1aNZqdCAiLNHK,RnDGWPheNNtOoqj4cZpwOa" IsHidden="true" />
+          <Link Id="ElI9sPVNZ3LLFtzgEXNhn4" Ids="CKDQPIhsAHeOT8MrxGai2Q,ONFlSRZK5eEQP0iSOxD7Kn" />
+          <Link Id="JKBFg7AwW28MrxxM5dTx2z" Ids="BUfifQmuFnOPh4vFAA7jWF,CKDQPIhsAHeOT8MrxGai2Q" IsHidden="true" />
+          <Link Id="OCQDl2mSrDOLDKRSvyWZTu" Ids="EI9rYLxxtgvMuFwhm249Ek,IR8WEENtRIoN38qxB6nMXk" />
+          <Link Id="Ijt8TGpwp8HMXp1p9Fe6iv" Ids="UGUlHGfGAMdNlMxI7xJVvM,EI9rYLxxtgvMuFwhm249Ek" IsHidden="true" />
+          <Link Id="AiNBV86xL0zMmG2qhadsFx" Ids="LyeU9D0sVyTMf00M6lYVJq,Q3kKy8kUaVqLOc28WSHpBk" />
+          <Link Id="QAuxFYd0wjeMcbvt14AW3V" Ids="GkCKaPChz0nOctZkvs83ve,FTuIfPF5EoYL1Dj4iCi7nM" />
+          <Link Id="PlEYbW5FrZkM2bEn44bcUp" Ids="FTuIfPF5EoYL1Dj4iCi7nM,CfOEGZyz8KKNojx2SryHDR" IsHidden="true" />
+          <Link Id="TzcmL1QaRHIQLrpFW8EWpk" Ids="Co1oz1E2483Oz0Og4xpafx,SIODnmGHjxvPl5n9nIvTqR" />
+          <Link Id="SpYyOK9xA0mLTVHbKhHNi9" Ids="SIODnmGHjxvPl5n9nIvTqR,VIKnINEkgXzMLp1nSxjcsH" IsHidden="true" />
+          <Link Id="NxHKBStWSYTPhE5cbJF1OC" Ids="HdIxgeNRl8oPAVzj6xhAoC,QNoT9qo5G1gPPIZgx09Cyb" />
+          <Link Id="KV5fajsexpoOTe9QXtyzlv" Ids="QNoT9qo5G1gPPIZgx09Cyb,MC0DteuHyPzNXaXQlTvMsb" IsHidden="true" />
+          <Link Id="KCpqVZCSMaYPMlzpNO77Av" Ids="DLIoa3mJyX0PxCctWeBcxl,QDXs9hrGwH8Lqm8kI5CpiA" />
+          <Link Id="FpNZ3HSsBp0NCClCKDLUhv" Ids="QDXs9hrGwH8Lqm8kI5CpiA,RqqWl2GInZBMI2kr1Gto5Q" IsHidden="true" />
+          <Link Id="Rs6sK8bIY7qPxGNrmGieTj" Ids="Q9p3xLGZ1rOK9VXpMDe32D,Fma6Vc5v4KkO88yDpNlJsq" />
+          <Link Id="UF4QW7wWbeiL9XisqooL9i" Ids="Fma6Vc5v4KkO88yDpNlJsq,VOoTkLm6vgjNwpkvbGNRER" IsHidden="true" />
+          <Link Id="S28mQppz0npOM8AsiGly93" Ids="U0UAfXWIeLkPyvSZ2xkRLV,Sne3mzcRCaaOB8ddOLzVAt" />
+          <Link Id="T9dzV7ljjVLPAdB5mAM1dL" Ids="LyeU9D0sVyTMf00M6lYVJq,DX6Jbe3rZukNbyXEZhTBl8" />
+          <Link Id="Q56HlMGKRTZP4d0s5dRIaF" Ids="BDsu1dXri96LoOHRN9G9PH,D1bqagXOw57PABrGt9cEQh" />
+          <Link Id="AG3RJcDB6g3NHkr9vJL7Rd" Ids="Sx4dptkgIkPLF8nncdOI7K,BDsu1dXri96LoOHRN9G9PH" IsHidden="true" />
+          <Link Id="UjIW2XUaov6NqzvnGGbXnL" Ids="UA9RK1FzsznPwM4QDGnfHl,LcnsLfRTdKMLOMnbhIdnX8" />
+          <Link Id="GoKzP0jNK4ALtxYrvMxNlS" Ids="LcnsLfRTdKMLOMnbhIdnX8,TJfZCGDLFdZL6E4zywYf3k" IsHidden="true" />
+          <Link Id="VspLv3fhRwbLsWZmoadlyR" Ids="JNyXmseqCZlNxnIbl2ABdI,HvzdTeBTs4PQHFu3DTMdAJ" IsHidden="true" />
+          <Link Id="ECjMThppbYgQCjuiTLGpDn" Ids="FKsTvJSEOgoPEMLVjcpv79,JNyXmseqCZlNxnIbl2ABdI" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ SetNotifyIconBalloonSettings (Internal) ************************
+
+-->
+      <Node Name="SetNotifyIconBalloonSettings (Internal)" Bounds="1090,1218" Id="AdfkjfAZrKaMNKWf9KVRfz" Summary="Sets the balloon settings for the notify icon and displays it." Remarks="Banging the Show Balloon Tip input will show a notification in Windows. Sometimes it just adds an entry to the Notification center, sometimes it actually shows the icon. Gotta dig that.">
+        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <Choice Kind="ContainerDefinition" Name="Process" />
+        </p:NodeReference>
+        <Patch Id="D9jbfxb9qwQOEbWtTUHGsX">
+          <Canvas Id="BriGHAbuWYgN9t9fH7upg1" CanvasType="Group">
+            <Node Bounds="371,424,162,182" Id="HO7z38YJRZDNH0iHUUgBIX">
+              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                <FullNameCategoryReference ID="Primitive" />
+              </p:NodeReference>
+              <Pin Id="UjW4yYjuZ8bPjZA8HYrJyb" Name="Force" Kind="InputPin" />
+              <Pin Id="TLgHP9nhye0NAsgMdEGfrS" Name="Dispose Cached Outputs" Kind="InputPin" />
+              <Pin Id="Gh2kodjORcUPIUkRhtRrO1" Name="Has Changed" Kind="OutputPin" />
+              <Patch Id="KJZMGHrj4JDPUCvazfL76h" ManuallySortedPins="true">
+                <Patch Id="PZVDm6TjImcLPzmxKCHKhn" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="Qc1BJoJ7fBXMy2I3YboFNg" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="383,466,98,26" Id="BJKAQbIvKOVNTBXWCJ4Cyw">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                    <Choice Kind="OperationCallFlag" Name="SetBalloonTipTitle" />
+                  </p:NodeReference>
+                  <Pin Id="FNX0VdtwE7AOrHhvtNFeoL" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="Ln23x4wdn5JL7qN17JQvAT" Name="Value" Kind="InputPin" />
+                  <Pin Id="BW6WcaJDYj8NLr6PqkuKuI" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="383,515,118,26" Id="Sywx2DmJugbLllP7UjajVB">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="SetBalloonTipText" />
+                  </p:NodeReference>
+                  <Pin Id="RLPrvhPrUmNPXkgXstbD0p" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="VXwQjlpzVxDLyH6l16VELM" Name="Value" Kind="InputPin" />
+                  <Pin Id="CWwJqibkDH5MqYcwmcgK1O" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="383,561,137,26" Id="B59oHQ1SQSlL6V3kVAsYps">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="SetBalloonTipIcon" />
+                  </p:NodeReference>
+                  <Pin Id="Q6OKdA5uyx6PwEYsAMvLxB" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="IGankWnpHFRN1RGb1rhDfY" Name="Value" Kind="InputPin" />
+                  <Pin Id="BuiVHkhA8W6OvQGUPBbJxh" Name="Output" Kind="StateOutputPin" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="G8c7or4BgZpOvQBGbQLr9A" Bounds="478,431" Alignment="Top" />
+              <ControlPoint Id="Fb8EFlH4nJtLHGJpXrK4UG" Bounds="518,431" Alignment="Top" />
+              <ControlPoint Id="HOb6F05p9RrNf8RrZeDgYQ" Bounds="498,431" Alignment="Top" />
+            </Node>
+            <ControlPoint Id="JvEEwNGu6tqOVwsCYpJAsq" Bounds="478,356" />
+            <ControlPoint Id="MxPpWpeSAdLNRMaHfyWXBI" Bounds="518,387" />
+            <ControlPoint Id="UL7jW2gWqlaOoR26Ym63et" Bounds="498,371" />
+            <ControlPoint Id="E9iQWBfD0Z4PkZUEBAfntB" Bounds="384,386" />
+            <Node Bounds="605,493,88,26" Id="FANMTte0fOCQZSyvp3KXle">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="ShowBalloonTip" />
+                <PinReference Kind="InputPin" Name="this">
+                  <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="TypeFlag" Name="NotifyIcon" />
+                  </p:DataTypeReference>
+                </PinReference>
+              </p:NodeReference>
+              <Pin Id="MIQ9POfHummNeVcVsFxdLS" Name="Input" Kind="StateInputPin" />
+              <Pin Id="KnI07VmVmolMTijCLLcTVv" Name="Timeout" Kind="InputPin" />
+              <Pin Id="Fe3AVEWTkp7PPls2LvziiJ" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="KKva1I576ejNgwFJnLR2iQ" Name="Apply" Kind="InputPin" />
+            </Node>
+            <ControlPoint Id="Hu3UdvyBlFLM87sIE90Odt" Bounds="690,468" />
+            <ControlPoint Id="Bv25rV9s867PoHNdXZBL59" Bounds="607,471" />
+          </Canvas>
+          <Patch Id="IIjiqEDkJx7QPth8Wh0gvZ" Name="Create" />
+          <Patch Id="KvFzduIFPn9Mrz2sD51uJg" Name="Update">
+            <Pin Id="D3g8ReCD61AMZaxW7SWif2" Name="Tip Title" Kind="InputPin" Bounds="248,205" DefaultValue="Notification Title">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="DfOcRW7cFoxMphTKwAV79P" Name="Tip Icon" Kind="InputPin" Bounds="297,202" DefaultValue="Info">
+              <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="TypeFlag" Name="ToolTipIcon" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="AdVYlnKbeGxMK2YYwKUCsP" Name="Tip Text" Kind="InputPin" Bounds="252,204" DefaultValue="Notification Text">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="TmoQboTMYBWQRhSTSQ9J9u" Name="Input" Kind="InputPin" Bounds="393,370" />
+            <Pin Id="GcmeWOv4kPsQCB5GUDVgQN" Name="Show Balloon Tip" Kind="InputPin" Bounds="215,404" DefaultValue="False">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+          </Patch>
+          <ProcessDefinition Id="EPHrdg2v1YCLQre3Pjfady">
+            <Fragment Id="Frp5PtgaQJKQBozXLQvrZx" Patch="IIjiqEDkJx7QPth8Wh0gvZ" Enabled="true" />
+            <Fragment Id="JUBkdQY7e5XOG64iXy15rt" Patch="KvFzduIFPn9Mrz2sD51uJg" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="IKW6q0nz4nlP1VYi46LS6B" Ids="JvEEwNGu6tqOVwsCYpJAsq,G8c7or4BgZpOvQBGbQLr9A" />
+          <Link Id="MrO0iuzeVYmNhQqxfCBZOf" Ids="D3g8ReCD61AMZaxW7SWif2,JvEEwNGu6tqOVwsCYpJAsq" IsHidden="true" />
+          <Link Id="OnSuxvSKgbTPcy8NL1k0DL" Ids="MxPpWpeSAdLNRMaHfyWXBI,Fb8EFlH4nJtLHGJpXrK4UG" />
+          <Link Id="V7ZteQTJ28CMQyI4w1GQWZ" Ids="DfOcRW7cFoxMphTKwAV79P,MxPpWpeSAdLNRMaHfyWXBI" IsHidden="true" />
+          <Link Id="FP6HQva1FO1P15BNLru5E1" Ids="UL7jW2gWqlaOoR26Ym63et,HOb6F05p9RrNf8RrZeDgYQ" />
+          <Link Id="BPefgNbXYAJOG6IAnW19BI" Ids="AdVYlnKbeGxMK2YYwKUCsP,UL7jW2gWqlaOoR26Ym63et" IsHidden="true" />
+          <Link Id="S1jG0iQoj2hOzfCxjSas6H" Ids="G8c7or4BgZpOvQBGbQLr9A,Ln23x4wdn5JL7qN17JQvAT" />
+          <Link Id="UzBqyCxRjtOPK1YhlOlioH" Ids="BW6WcaJDYj8NLr6PqkuKuI,RLPrvhPrUmNPXkgXstbD0p" />
+          <Link Id="KUHQ6vTsbahPnfUaW2b4wu" Ids="HOb6F05p9RrNf8RrZeDgYQ,VXwQjlpzVxDLyH6l16VELM" />
+          <Link Id="P7g7Wn616qcOcJQJgNZrTX" Ids="CWwJqibkDH5MqYcwmcgK1O,Q6OKdA5uyx6PwEYsAMvLxB" />
+          <Link Id="KGJnAb1H8VJNEXgiEEUkUa" Ids="Fb8EFlH4nJtLHGJpXrK4UG,IGankWnpHFRN1RGb1rhDfY" />
+          <Link Id="R34gjEA0fI4NDxWs2LIwFm" Ids="E9iQWBfD0Z4PkZUEBAfntB,FNX0VdtwE7AOrHhvtNFeoL" />
+          <Link Id="EgzaN149l7xOUsuV7j6oms" Ids="TmoQboTMYBWQRhSTSQ9J9u,E9iQWBfD0Z4PkZUEBAfntB" IsHidden="true" />
+          <Link Id="FcQ4f3xzgrJOFfiXWRIjC0" Ids="Hu3UdvyBlFLM87sIE90Odt,KKva1I576ejNgwFJnLR2iQ" />
+          <Link Id="IXqxWz4Mm5eNMQsWLzLVWC" Ids="GcmeWOv4kPsQCB5GUDVgQN,Hu3UdvyBlFLM87sIE90Odt" IsHidden="true" />
+          <Link Id="Id9zOdvnUL1NUZZJbxdAOS" Ids="Bv25rV9s867PoHNdXZBL59,MIQ9POfHummNeVcVsFxdLS" />
+          <Link Id="BHPbiLP0MlvMOAT7H5aUlY" Ids="TmoQboTMYBWQRhSTSQ9J9u,Bv25rV9s867PoHNdXZBL59" IsHidden="true" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ SetNotifyIconIconOrDefault (Internal) ************************
+
+-->
+      <Node Name="SetNotifyIconIconOrDefault (Internal)" Bounds="1090,1261" Id="DaflZBUHPmqOyMwmpbHrCo" Summary="Sets a custom icon on the Notify Icon, or uses the assembly's one.">
+        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <Choice Kind="ContainerDefinition" Name="Process" />
+        </p:NodeReference>
+        <Patch Id="CYnH6O97XPKOIOz3KM9VrC">
+          <Canvas Id="VBdW80CfBPAMofjTCEoOHk" CanvasType="Group">
+            <ControlPoint Id="MIiolSZJoSJOeKHGLzMaDT" Bounds="361,251" />
+            <Node Bounds="323,282,238,326" Id="RyqSsFqSUfAMfwxvaYzQ2D">
+              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                <FullNameCategoryReference ID="Primitive" />
+              </p:NodeReference>
+              <Pin Id="RtRaG6Vkmd4OlR6O6YNIwB" Name="Force" Kind="InputPin" />
+              <Pin Id="OjzHNb600MzNC0Jrv2eleI" Name="Dispose Cached Outputs" Kind="InputPin" />
+              <Pin Id="OqsKZDNy7iGP7NCogqscJv" Name="Has Changed" Kind="OutputPin" />
+              <Patch Id="BkbGZEeLzdrMkUDoLy2mLa" ManuallySortedPins="true">
+                <Patch Id="AeroT1MrfFSLtefuvTs11u" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="NU8HuWuf4mEOyCMbnrhrit" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="335,562,26,26" Id="GqmWUx2DhjfNIigrcQGiOK">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                    <Choice Kind="OperationCallFlag" Name="SetIcon" />
+                  </p:NodeReference>
+                  <Pin Id="PF8yJSuQ2pdLPDsVCBoTlE" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="C5g9Fyayx9rO4HKI0MynPQ" Name="Value" Kind="InputPin" />
+                  <Pin Id="MWJvY75grxPOTafi5ofxk0" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="359,342,25,19" Id="A3Ljw1HuDquQSdm50Kblzv">
+                  <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="=" />
+                  </p:NodeReference>
+                  <Pin Id="M4SZBJkb4aRLOlcBTNeW1m" Name="Input" Kind="InputPin" />
+                  <Pin Id="EqyI3m14TzULEFDvHOCqrF" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="IlIBMKfGMpqPhBzkr5PTnZ" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="379,311,40,19" Id="AGRgM3LGhyLN5jpY3Nu6th">
+                  <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="NULL" />
+                  </p:NodeReference>
+                  <Pin Id="VSLkjgmVhukNf46t1rfcp5" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="359,374,190,150" Id="GlL4U7U3pa1QBZnSyhLwPk">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                    <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:NodeReference>
+                  <Pin Id="Lc3BBmhYerQLvndgFQFxzo" Name="Condition" Kind="InputPin" />
+                  <Patch Id="KLy5NYRzMs7PLMfOojMSv9" ManuallySortedPins="true">
+                    <Patch Id="AA0vls3amogQchLIlBbgf2" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="IMJ7906FPaCLJI9rpaNaUw" Name="Then" ManuallySortedPins="true" />
+                    <Node Bounds="421,483,116,19" Id="VnQRwo78HcVLqrESOE1q7q">
+                      <p:NodeReference LastCategoryFullName="System.Drawing.Icon" LastSymbolSource="System.Drawing.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="ExtractAssociatedIcon" />
+                      </p:NodeReference>
+                      <Pin Id="RpcNbrx3vqvOVWYzW9sRyW" Name="File Path" Kind="InputPin" />
+                      <Pin Id="UZiKQHjIUo0PTb4pJQ22WD" Name="Result" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="371,439,55,26" Id="EjiuKlqU4KXPSJ5xnuloQ4">
+                      <p:NodeReference LastCategoryFullName="System.Reflection.Assembly" LastSymbolSource="System.Reflection.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="Location" />
+                        <CategoryReference Kind="AssemblyCategory" Name="Assembly" NeedsToBeDirectParent="true" />
+                      </p:NodeReference>
+                      <Pin Id="CH8Q0Do9iKVLJQCvF4A6NN" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="AiXnuwCARknLglctOa5ihS" Name="Output" Kind="StateOutputPin" />
+                      <Pin Id="N7PuPqKx4cHNNViVHeh8sz" Name="Location" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="371,404,98,19" Id="AYAPn1vZOqdLCFJd8Tl4u7">
+                      <p:NodeReference LastCategoryFullName="System.Reflection.Assembly" LastSymbolSource="System.Reflection.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="GetEntryAssembly" />
+                      </p:NodeReference>
+                      <Pin Id="LERO1lwDWq8QTPgGJzUE1V" Name="Result" Kind="OutputPin" />
+                    </Node>
+                  </Patch>
+                  <ControlPoint Id="CkxgiaGEczCPueHbRL1xIj" Bounds="423,518" Alignment="Bottom" />
+                  <ControlPoint Id="EFA044nlyRSPl1J0tGZHQO" Bounds="480,380" Alignment="Top" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="N9MjHxQqCBxMmvvGUkDLYG" Bounds="361,288" Alignment="Top" />
+            </Node>
+            <ControlPoint Id="L5Bxq6tG0AfQIXbjfLJZFI" Bounds="339,219" />
+          </Canvas>
+          <Patch Id="IjIYsbIDKInQBdX1rVUFNn" Name="Create" />
+          <Patch Id="RoFtm744LkBPi7QPLd2Wpn" Name="Update">
+            <Pin Id="SbV9fpUW9K3PWoNLZpGcNP" Name="Icon" Kind="InputPin" Bounds="403,373">
+              <p:TypeAnnotation LastCategoryFullName="System.Drawing" LastSymbolSource="System.Drawing.dll">
+                <Choice Kind="TypeFlag" Name="Icon" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="D2T3kHr0cluOGJi8NTdnD8" Name="Input" Kind="InputPin" Bounds="339,218" />
+          </Patch>
+          <ProcessDefinition Id="HRl7Pm5tHKcLeDrfwiqikT">
+            <Fragment Id="VVq4JsAkyP8LsY3oTKgpxj" Patch="IjIYsbIDKInQBdX1rVUFNn" Enabled="true" />
+            <Fragment Id="PqWRafzHf4pLTGN4NFZFJA" Patch="RoFtm744LkBPi7QPLd2Wpn" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="BOB748fwOKuP3tOxjw4PCD" Ids="SbV9fpUW9K3PWoNLZpGcNP,MIiolSZJoSJOeKHGLzMaDT" IsHidden="true" />
+          <Link Id="APBye2PXL6dPAclM4tdGIS" Ids="MIiolSZJoSJOeKHGLzMaDT,N9MjHxQqCBxMmvvGUkDLYG" />
+          <Link Id="QlGVZh6So93QYunTHg0K8N" Ids="VSLkjgmVhukNf46t1rfcp5,EqyI3m14TzULEFDvHOCqrF" />
+          <Link Id="SPHN64REsCoOwSQ9jQkgvb" Ids="N9MjHxQqCBxMmvvGUkDLYG,M4SZBJkb4aRLOlcBTNeW1m" />
+          <Link Id="IkpGFDyNs1uMVq3TRWcQfu" Ids="IlIBMKfGMpqPhBzkr5PTnZ,Lc3BBmhYerQLvndgFQFxzo" />
+          <Link Id="DLOC8IpyOEWMcwdUM6c5zT" Ids="N7PuPqKx4cHNNViVHeh8sz,RpcNbrx3vqvOVWYzW9sRyW" />
+          <Link Id="Uiv9FZFL2T5P5D3OM2TEfF" Ids="LERO1lwDWq8QTPgGJzUE1V,CH8Q0Do9iKVLJQCvF4A6NN" />
+          <Link Id="PRhVa2D1YEpObj8YYC9Ys0" Ids="EFA044nlyRSPl1J0tGZHQO,CkxgiaGEczCPueHbRL1xIj" IsFeedback="true" />
+          <Link Id="Qy1pScEPRXkP3xq3K5RAE6" Ids="UZiKQHjIUo0PTb4pJQ22WD,CkxgiaGEczCPueHbRL1xIj" />
+          <Link Id="GXmCDbQ4npbQcVCmNmuFov" Ids="N9MjHxQqCBxMmvvGUkDLYG,EFA044nlyRSPl1J0tGZHQO" />
+          <Link Id="RubuJxOh5rDQGceseLiroR" Ids="CkxgiaGEczCPueHbRL1xIj,C5g9Fyayx9rO4HKI0MynPQ" />
+          <Link Id="HhD5sjDg12WQOJPfActgf9" Ids="L5Bxq6tG0AfQIXbjfLJZFI,PF8yJSuQ2pdLPDsVCBoTlE" />
+          <Link Id="Lute9zjCF2nMdp1PFD9t3K" Ids="D2T3kHr0cluOGJi8NTdnD8,L5Bxq6tG0AfQIXbjfLJZFI" IsHidden="true" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ GetNotifyIconClickEvents (Internal) ************************
+
+-->
+      <Node Name="GetNotifyIconClickEvents (Internal)" Bounds="1090,1304" Id="RIXciikDgBcMNv7psXrbTj" Summary="Outputs mouse events on the notify icon">
+        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <Choice Kind="ContainerDefinition" Name="Process" />
+        </p:NodeReference>
+        <Patch Id="SriUbo46bekOacCD0y3hXO">
+          <Canvas Id="FnpraegnCFJPvIeBKEgnuV" CanvasType="Group">
+            <Node Bounds="185,210,100,26" Id="GXlOJC3kTsHNr5QzX3tA0M">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                <Choice Kind="OperationCallFlag" Name="MouseDoubleClick" />
+              </p:NodeReference>
+              <Pin Id="DGkv07z6zD7N6c2ZocYkv5" Name="Input" Kind="StateInputPin" />
+              <Pin Id="AIm5U0BfxBrPT1gghAwUXX" Name="Result" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="CnVIIVYULoqLYzgb6yVEd8" Bounds="94,131" />
+            <ControlPoint Id="A0nA4cezSqIN0zhr5U3FsK" Bounds="187,274" />
+            <Node Bounds="93,210,68,26" Id="SDIm5cleM5jLLqtDH7WG9y">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                <Choice Kind="OperationCallFlag" Name="MouseClick" />
+              </p:NodeReference>
+              <Pin Id="JRfUSnUWBdRLXhEkQMTRmt" Name="Input" Kind="StateInputPin" />
+              <Pin Id="MB25PvxKdfwPE2CUbKjrvh" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="396,210,72,26" Id="ISMm5qfTXrmP4tTgZnV6EZ">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                <Choice Kind="OperationCallFlag" Name="MouseDown" />
+              </p:NodeReference>
+              <Pin Id="L1Phd57i32SMi2a7Nucaml" Name="Input" Kind="StateInputPin" />
+              <Pin Id="SGFP67yAZlwMBdAjyjO9DP" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="301,210,70,26" Id="M8DRh2HG42bMXMB6B43gGg">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                <Choice Kind="OperationCallFlag" Name="MouseMove" />
+              </p:NodeReference>
+              <Pin Id="PEWdjHCtfj7OZR4z1YihVA" Name="Input" Kind="StateInputPin" />
+              <Pin Id="Orr0tQlDmqOPWYqpFddqyI" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="498,210,58,26" Id="Sp9txMCBRwHO5VHwHJrBSH">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="MouseUp" />
+                <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="IdfZf9ZrkcZODNBq1is7jl" Name="Input" Kind="StateInputPin" />
+              <Pin Id="TRtMDBjTKDyNKLYjtcJTFK" Name="Result" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="U9VCb3vwzl7M3mYYrTEcIM" Bounds="500,274" />
+            <ControlPoint Id="LZlJ6DULT7mQOLCiOTmZNf" Bounds="303,274" />
+            <ControlPoint Id="KlqJy69hVvFMKIrDKhcsQL" Bounds="398,274" />
+            <ControlPoint Id="ORbCIIaMnWcNbXI3CWzOkL" Bounds="95,274" />
+          </Canvas>
+          <Patch Id="Isf7GHaHHK6L9ZNMyEbAeL" Name="Create" />
+          <Patch Id="AmuhAjXMh4LMdjDxKl0BJe" Name="Update">
+            <Pin Id="Vl1SN1zTXTYOye8f8YHJh5" Name="Input" Kind="InputPin" Bounds="525,587" />
+            <Pin Id="BDGFBCpQY3EMbf6KalZ1p7" Name="On Double Click" Kind="OutputPin" Bounds="613,774" />
+            <Pin Id="PFMmBQhTQusMbxOlqP6amA" Name="On Mouse Up" Kind="OutputPin" Bounds="644,878" />
+            <Pin Id="EgImtBKqztmPr2IUNSrzo1" Name="On Mouse Move" Kind="OutputPin" Bounds="539,890" />
+            <Pin Id="AwOH9vm9qqiQMW2lGb2dmm" Name="On Mouse Down" Kind="OutputPin" Bounds="437,867" />
+            <Pin Id="JQvcfWT7kegQZg9TDfMMCj" Name="On Mouse Click" Kind="OutputPin" Bounds="339,776" />
+          </Patch>
+          <ProcessDefinition Id="SQXdoCx0yHdPuPQ52FcjQK">
+            <Fragment Id="F3NYFQR6heCNjNYGV7jt0a" Patch="Isf7GHaHHK6L9ZNMyEbAeL" Enabled="true" />
+            <Fragment Id="Qw9FuyMlZGUOaTt6aZ62gj" Patch="AmuhAjXMh4LMdjDxKl0BJe" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="Pn73pFGBcFvQZB9gQvnJ2J" Ids="CnVIIVYULoqLYzgb6yVEd8,DGkv07z6zD7N6c2ZocYkv5" />
+          <Link Id="Id2ZumC0fQuP0feOCf8gjX" Ids="Vl1SN1zTXTYOye8f8YHJh5,CnVIIVYULoqLYzgb6yVEd8" IsHidden="true" />
+          <Link Id="HQcifArRHiJN7rZLeq62mA" Ids="AIm5U0BfxBrPT1gghAwUXX,A0nA4cezSqIN0zhr5U3FsK" />
+          <Link Id="BX6BhFxsq5FQSyoHtvpaGZ" Ids="A0nA4cezSqIN0zhr5U3FsK,BDGFBCpQY3EMbf6KalZ1p7" IsHidden="true" />
+          <Link Id="KOvcUY3xQMyOKmNpQiHTpD" Ids="CnVIIVYULoqLYzgb6yVEd8,JRfUSnUWBdRLXhEkQMTRmt" />
+          <Link Id="O72Ndn4agVjLHBm1lxNh9P" Ids="CnVIIVYULoqLYzgb6yVEd8,L1Phd57i32SMi2a7Nucaml" />
+          <Link Id="EkxwBtVoCCMPBScxQjtwut" Ids="CnVIIVYULoqLYzgb6yVEd8,PEWdjHCtfj7OZR4z1YihVA" />
+          <Link Id="QEz8qu7AFoWMh7qbFxxw0j" Ids="CnVIIVYULoqLYzgb6yVEd8,IdfZf9ZrkcZODNBq1is7jl" />
+          <Link Id="SwzJWQlB7dVOM6lE9KuedS" Ids="TRtMDBjTKDyNKLYjtcJTFK,U9VCb3vwzl7M3mYYrTEcIM" />
+          <Link Id="Kdx90n7HQxRQP2gr9j0tsn" Ids="U9VCb3vwzl7M3mYYrTEcIM,PFMmBQhTQusMbxOlqP6amA" IsHidden="true" />
+          <Link Id="Lo36KoU1W5PN6NypBeXup4" Ids="Orr0tQlDmqOPWYqpFddqyI,LZlJ6DULT7mQOLCiOTmZNf" />
+          <Link Id="JqIDvVfrXj9NFx2HoaAE1h" Ids="LZlJ6DULT7mQOLCiOTmZNf,EgImtBKqztmPr2IUNSrzo1" IsHidden="true" />
+          <Link Id="Poo7rTXzt5SMUQ6Vcnv3fR" Ids="SGFP67yAZlwMBdAjyjO9DP,KlqJy69hVvFMKIrDKhcsQL" />
+          <Link Id="UOiUthdenC1OI7nBxHNyIe" Ids="KlqJy69hVvFMKIrDKhcsQL,AwOH9vm9qqiQMW2lGb2dmm" IsHidden="true" />
+          <Link Id="EJ0hnY48tHDLcslMQaKVKa" Ids="MB25PvxKdfwPE2CUbKjrvh,ORbCIIaMnWcNbXI3CWzOkL" />
+          <Link Id="C6hz1tKiIe5OveyMPsdpKl" Ids="ORbCIIaMnWcNbXI3CWzOkL,JQvcfWT7kegQZg9TDfMMCj" IsHidden="true" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ NotifyIconContextMenu (Internal) ************************
+
+-->
+      <Node Name="NotifyIconContextMenu (Internal)" Bounds="1090,1347" Id="GFfQAPeB6WMNB4yHLcvItz" Summary="Adds entry to the notify icon's context menu, and outputs a spread of observables that fires when those are clicked">
+        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <Choice Kind="ContainerDefinition" Name="Process" />
+        </p:NodeReference>
+        <Patch Id="KPe4aCSArRXLrNxIjkIF9J">
+          <Canvas Id="CTY9MAYueFQNd5uCssqk7r" CanvasType="Group">
+            <Node Bounds="307,338,277,290" Id="TySsrzcCIpoMWe3CWD80el">
+              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                <FullNameCategoryReference ID="Primitive" />
+              </p:NodeReference>
+              <Pin Id="KUyxJdmHZ4LPmTSyePkXYy" Name="Force" Kind="InputPin" />
+              <Pin Id="IfeUY0akRhBLT2I3mF6H91" Name="Dispose Cached Outputs" Kind="InputPin" />
+              <Pin Id="VWQmQms0RXOPElKw3dGv9h" Name="Has Changed" Kind="OutputPin" />
+              <Patch Id="RiPl8u0azaELpgnj9oQAnx" ManuallySortedPins="true">
+                <Patch Id="KeXMEE5f3JeP71pin5NSLg" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="LBxEDjuSqMOOBMElS7UR3t" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="405,542,64,26" Id="B6gXl0bCxn3Le4zWI3MdJE">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.ContextMenu" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="ContextMenu" />
+                    <Choice Kind="OperationCallFlag" Name="Create" />
+                    <PinReference Kind="InputPin" Name="Menu Items" />
+                  </p:NodeReference>
+                  <Pin Id="DGXtDmSOzFdLLm9ZoSaj26" Name="Menu Items" Kind="InputPin" />
+                  <Pin Id="UIsQoiT0ZGdLQNlS7GTExh" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="393,361,179,124" Id="AHIUYpt3f9PPiE2FcWplPX">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                    <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                    <FullNameCategoryReference ID="Primitive" />
+                  </p:NodeReference>
+                  <Pin Id="DllYo23weXKMozFYXxPIR0" Name="Break" Kind="OutputPin" />
+                  <Patch Id="QWrall8G2qaPRtvxYnjTYP" ManuallySortedPins="true">
+                    <Patch Id="CCSuZ3FbXQ5OtEpP2ugZPk" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="CA5ukj6VZmcQV2WkNlle0N" Name="Update" ManuallySortedPins="true" />
+                    <Patch Id="VltOcikOyMJMZzJ2oWcLbJ" Name="Dispose" ManuallySortedPins="true" />
+                    <Node Bounds="405,384,52,26" Id="ODywIP1y2S4LZmmwKV570s">
+                      <p:NodeReference LastCategoryFullName="System.Windows.Forms.MenuItem" LastSymbolSource="System.Windows.Forms.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="AssemblyCategory" Name="MenuItem" />
+                        <Choice Kind="OperationCallFlag" Name="Create" />
+                        <PinReference Kind="InputPin" Name="Text" />
+                      </p:NodeReference>
+                      <Pin Id="L03nfansaLsPVhwkdX7adI" Name="Text" Kind="InputPin" />
+                      <Pin Id="I7HiyVCR3xOObhCm8VSqaI" Name="Output" Kind="StateOutputPin" />
+                    </Node>
+                    <Node Bounds="508,434,52,26" Id="GNpqFpNpOikNjO0JG8h5Gb">
+                      <p:NodeReference LastCategoryFullName="System.Windows.Forms.MenuItem" LastSymbolSource="System.Windows.Forms.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="AssemblyCategory" Name="MenuItem" />
+                        <Choice Kind="OperationCallFlag" Name="Click" />
+                      </p:NodeReference>
+                      <Pin Id="Ct0ex1S6d9aO0vyKRMKXcF" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="TsnnSwpkITePLbIq84ifLP" Name="Result" Kind="OutputPin" />
+                    </Node>
+                  </Patch>
+                  <ControlPoint Id="Us1KmLMSoV9QLp5PqcE5Ym" Bounds="407,369" Alignment="Top" />
+                  <ControlPoint Id="QkYlWbwLnafL5SFgxLdA4R" Bounds="407,471" Alignment="Bottom" />
+                  <ControlPoint Id="UhVmMmTvINOPRWvjuefeVb" Bounds="510,480" Alignment="Bottom" />
+                </Node>
+                <Node Bounds="319,582,91,26" Id="KXTPEN2ivNvOwYu7BwsII5">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastSymbolSource="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="SetContextMenu" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="DdfQGDcMnyVL3XSgQnbZ4b" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="VbPfYRJKd6gMAjD6vrK7WJ" Name="Value" Kind="InputPin" />
+                  <Pin Id="HG1Wld6PtLcNec2z6CwTN8" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="405,501,83,26" Id="SK9KV3Iwi7PMP16mwqa4o2">
+                  <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArray" LastSymbolSource="VL.Collections.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="FromSequence" />
+                    <CategoryReference Kind="ArrayType" Name="MutableArray" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="C0mApucgv2wMENtILYHi1Y" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="AuA9BXPnnU7PbNWiLeWDr6" Name="Result" Kind="OutputPin" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="U5phsut5uTmL593Mv8lrhU" Bounds="407,345" Alignment="Top" />
+              <ControlPoint Id="Hb9BxnYjHktLEgwPFlHKYd" Bounds="510,622" Alignment="Bottom" />
+            </Node>
+            <ControlPoint Id="QqhZLTrcs1YLzSTxlm2sSs" Bounds="407,312" />
+            <ControlPoint Id="B8BxX7nHMUuMf4LvKVhPsw" Bounds="320,313" />
+            <ControlPoint Id="ATMAuSBG9hyLKgQ1CWHmhu" Bounds="510,670" />
+          </Canvas>
+          <Patch Id="GVcJMncBqiQQVVRBjbiky4" Name="Create" />
+          <Patch Id="MUJNGVbdGtdQObskPDBuJg" Name="Update">
+            <Pin Id="QYPRVwcXeIdMTsbq96HHcN" Name="Context Menu Items" Kind="InputPin" Bounds="459,635" />
+            <Pin Id="JfDxxjKNtxiOwbc0IqHOAY" Name="Input" Kind="InputPin" Bounds="322,212" />
+            <Pin Id="I0SeNopkeVFPG3pHHMUG2l" Name="On Context Menu Items Click" Kind="OutputPin" Bounds="508,703" />
+          </Patch>
+          <ProcessDefinition Id="KGpzfLwQCouLAbMsuGOPYm">
+            <Fragment Id="LrnZYehQdrdPe4RAQMflzn" Patch="GVcJMncBqiQQVVRBjbiky4" Enabled="true" />
+            <Fragment Id="KCuM3ls5YkfMKyNER0KBhW" Patch="MUJNGVbdGtdQObskPDBuJg" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="K8eHpgLDEDeMWt1bwbyLxc" Ids="Us1KmLMSoV9QLp5PqcE5Ym,L03nfansaLsPVhwkdX7adI" />
+          <Link Id="NVPY489bpEsLhSBKcquvR0" Ids="U5phsut5uTmL593Mv8lrhU,Us1KmLMSoV9QLp5PqcE5Ym" />
+          <Link Id="R3JCjnjxGGuOKRg2cFW8eS" Ids="QqhZLTrcs1YLzSTxlm2sSs,U5phsut5uTmL593Mv8lrhU" />
+          <Link Id="Kzy2hR3G4dIOXUK0LoD0fC" Ids="QYPRVwcXeIdMTsbq96HHcN,QqhZLTrcs1YLzSTxlm2sSs" IsHidden="true" />
+          <Link Id="KJ1BalDB9cKNJ0XnoEbEMT" Ids="I7HiyVCR3xOObhCm8VSqaI,QkYlWbwLnafL5SFgxLdA4R" />
+          <Link Id="G3nFIw1ljEbLl1pzDJSto3" Ids="UIsQoiT0ZGdLQNlS7GTExh,VbPfYRJKd6gMAjD6vrK7WJ" />
+          <Link Id="AMfxov4Jd1pNOr7GO8CVK9" Ids="QkYlWbwLnafL5SFgxLdA4R,C0mApucgv2wMENtILYHi1Y" />
+          <Link Id="VEaNk7hA9lrO17RPIiHQg9" Ids="AuA9BXPnnU7PbNWiLeWDr6,DGXtDmSOzFdLLm9ZoSaj26" />
+          <Link Id="RZGcsrssDmKM8SOfufBfeB" Ids="B8BxX7nHMUuMf4LvKVhPsw,DdfQGDcMnyVL3XSgQnbZ4b" />
+          <Link Id="MesHDQFRvWyLm93q2CdZOb" Ids="JfDxxjKNtxiOwbc0IqHOAY,B8BxX7nHMUuMf4LvKVhPsw" IsHidden="true" />
+          <Link Id="HbbjfydrtErPEqcDprqJet" Ids="I7HiyVCR3xOObhCm8VSqaI,Ct0ex1S6d9aO0vyKRMKXcF" />
+          <Link Id="Mo381F4Gg5JQcdsi3wJ2LP" Ids="TsnnSwpkITePLbIq84ifLP,UhVmMmTvINOPRWvjuefeVb" />
+          <Link Id="E61uGyPnHZmMaM0XOroqZn" Ids="UhVmMmTvINOPRWvjuefeVb,Hb9BxnYjHktLEgwPFlHKYd" />
+          <Link Id="QM25uXhLswnPyJIkVu5UE5" Ids="Hb9BxnYjHktLEgwPFlHKYd,ATMAuSBG9hyLKgQ1CWHmhu" />
+          <Link Id="SmzzhpuxpfpMqxhaMzQWR2" Ids="ATMAuSBG9hyLKgQ1CWHmhu,I0SeNopkeVFPG3pHHMUG2l" IsHidden="true" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ Minimize ************************
+
+-->
+      <Node Name="Minimize" Bounds="926,1027" Id="HAfwv50UHguOKsrJlRjxNs" Summary="Minimizes the attached Renderer">
+        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <Choice Kind="ContainerDefinition" Name="Process" />
+        </p:NodeReference>
+        <Patch Id="TLxAaNR1tqaPYJeqcGtZGI">
+          <Canvas Id="S4LwGYDrHwuPK8oJYB24W0" CanvasType="Group">
+            <Node Bounds="416,507" Id="Ij1n6fLAWMzOusqlOC0KVm">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="SetWindowState" />
+                <CategoryReference Kind="AssemblyCategory" Name="Form" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="Gp7K5zEQ5TwPEb226ZgHGY" Name="Input" Kind="StateInputPin" />
+              <Pin Id="U88IYfWgPCTNJ7G866dpNB" Name="Value" Kind="InputPin" DefaultValue="Minimized">
+                <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                  <Choice Kind="TypeFlag" Name="FormWindowState" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="SWzTXLJS6KNOxYEtPKdbcV" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="Bmi74Vk6SbtQPEVkVaUFru" Name="Apply" Kind="InputPin" />
+            </Node>
+            <ControlPoint Id="Vy7uc5iNiIwQb3OWuNgleg" Bounds="418,478" />
+            <ControlPoint Id="EknWQ1Hk4HNOx2KOi5Gmfp" Bounds="418,556" />
+            <ControlPoint Id="H11aQ14weSYO00e333cHhV" Bounds="501,482" />
+          </Canvas>
+          <Patch Id="V2WH05usVMmN3XrwPp3Mc3" Name="Create" />
+          <Patch Id="LeoVPDq2EzNPntvV2iEYKs" Name="Update">
+            <Pin Id="Jorb3Su8OtrQZ8lCeorAfW" Name="Input" Kind="InputPin" Bounds="428,464">
+              <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="TypeFlag" Name="Form" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="Cq9vfa0ItXFMiqxI0CugUS" Name="Output" Kind="OutputPin" Bounds="415,565">
+              <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="TypeFlag" Name="Form" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="UgC9Mq0YiMWNZHvwmKRqXO" Name="Minimize" Kind="InputPin" Bounds="516,469" DefaultValue="False">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+          </Patch>
+          <ProcessDefinition Id="DROaqJSq024OUNxiMTybtF">
+            <Fragment Id="E6vDdj3LRGaMmqgGdEYxPx" Patch="V2WH05usVMmN3XrwPp3Mc3" Enabled="true" />
+            <Fragment Id="H6Lvk38TRRkOJxYVuiTUMP" Patch="LeoVPDq2EzNPntvV2iEYKs" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="SE4PQOhJYSGLE0QIBlMfxY" Ids="Vy7uc5iNiIwQb3OWuNgleg,Gp7K5zEQ5TwPEb226ZgHGY" />
+          <Link Id="Kam867GL96aOCoI8hYofHW" Ids="Jorb3Su8OtrQZ8lCeorAfW,Vy7uc5iNiIwQb3OWuNgleg" IsHidden="true" />
+          <Link Id="DSC0lCnvT96MRKLFihpxot" Ids="SWzTXLJS6KNOxYEtPKdbcV,EknWQ1Hk4HNOx2KOi5Gmfp" />
+          <Link Id="I9Hc6aUl1dUN1a0mDYbsak" Ids="EknWQ1Hk4HNOx2KOi5Gmfp,Cq9vfa0ItXFMiqxI0CugUS" IsHidden="true" />
+          <Link Id="JaK4O55seugMu84R3XoOKT" Ids="H11aQ14weSYO00e333cHhV,Bmi74Vk6SbtQPEVkVaUFru" />
+          <Link Id="QhrTlINlXzsQIWqIVgClAH" Ids="UgC9Mq0YiMWNZHvwmKRqXO,H11aQ14weSYO00e333cHhV" IsHidden="true" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ Show ************************
+
+-->
+      <Node Name="Show" Bounds="925,1144" Id="JU0xwnNQdHwMOa55d59cjA" Summary="Shows the attached Renderer.">
+        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <Choice Kind="ContainerDefinition" Name="Process" />
+        </p:NodeReference>
+        <Patch Id="J2IVNdSVIS3LKkbEaF90cb">
+          <Canvas Id="QT6FwcNNwRJNSJ7XRGk9ex" CanvasType="Group">
+            <Node Bounds="445,444" Id="BC3r1XsZThsPi0yPICLrmR">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="SetWindowState" />
+                <CategoryReference Kind="AssemblyCategory" Name="Form" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="CQaXft84SJzPn9rlNuFILq" Name="Input" Kind="StateInputPin" />
+              <Pin Id="QfDJ7kFTlA9OohO1umXJxO" Name="Value" Kind="InputPin">
+                <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                  <Choice Kind="TypeFlag" Name="FormWindowState" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="CNjigCUihgUO9Ykm9IIXlJ" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="OXJ6VpaRlSYPTSsjhjctM3" Name="Apply" Kind="InputPin" />
+            </Node>
+            <ControlPoint Id="HDil7lC4oPFLnDutrtAKaa" Bounds="447,415" />
+            <ControlPoint Id="Uk3woaUjTx6OowNQcBceKU" Bounds="447,493" />
+            <ControlPoint Id="LOHBP1o4zhdOC2RgVk9QNW" Bounds="530,419" />
+          </Canvas>
+          <Patch Id="Fj5QKSUQv8GOWhWFjn5RWX" Name="Create" />
+          <Patch Id="BfzXToSMCuVNxAbvMMDcrX" Name="Update">
+            <Pin Id="MQVMwcrXi7BObe2gwd6PXD" Name="Input" Kind="InputPin" Bounds="428,464">
+              <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="TypeFlag" Name="Form" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="Mw4tE88jIGOLjNtpq5dwbC" Name="Output" Kind="OutputPin" Bounds="415,565">
+              <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="TypeFlag" Name="Form" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="EGHAsnSHSMIN2JzvxKuP2Z" Name="Show" Kind="InputPin" Bounds="516,469" DefaultValue="False">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+          </Patch>
+          <ProcessDefinition Id="G14p0LbtnRpPEmwfiCej8h">
+            <Fragment Id="SuYENBjOHZ9PNwouSNznEV" Patch="Fj5QKSUQv8GOWhWFjn5RWX" Enabled="true" />
+            <Fragment Id="Dfiba9fiBERNZcDfbRR9Vj" Patch="BfzXToSMCuVNxAbvMMDcrX" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="QMeWmtqH1uNPuMeaAY6WiR" Ids="HDil7lC4oPFLnDutrtAKaa,CQaXft84SJzPn9rlNuFILq" />
+          <Link Id="AJq2KhEO5uJLqHaSpVMMh7" Ids="MQVMwcrXi7BObe2gwd6PXD,HDil7lC4oPFLnDutrtAKaa" IsHidden="true" />
+          <Link Id="LIXZWS3ncYQLuDnpvaVAe7" Ids="CNjigCUihgUO9Ykm9IIXlJ,Uk3woaUjTx6OowNQcBceKU" />
+          <Link Id="Ssz69eNdF9EPj9nwDydm6f" Ids="Uk3woaUjTx6OowNQcBceKU,Mw4tE88jIGOLjNtpq5dwbC" IsHidden="true" />
+          <Link Id="UojrKTEnOSLPuNiE2GPFHe" Ids="LOHBP1o4zhdOC2RgVk9QNW,OXJ6VpaRlSYPTSsjhjctM3" />
+          <Link Id="Qz9wGHrYjVYOPaVhJPbb9W" Ids="EGHAsnSHSMIN2JzvxKuP2Z,LOHBP1o4zhdOC2RgVk9QNW" IsHidden="true" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ Maximize ************************
+
+-->
+      <Node Name="Maximize" Bounds="922,1084" Id="RFGz9GmGjvvOtOFsVat625" Summary="Maximized the attached Renderer">
+        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <Choice Kind="ContainerDefinition" Name="Process" />
+        </p:NodeReference>
+        <Patch Id="NReKpi8OKX8OsB7iOKjFDL">
+          <Canvas Id="QEgNDfjEdWLMr7cgkn1X2v" CanvasType="Group">
+            <Node Bounds="423,493" Id="InGoAJlMq45MLQGogeqJZm">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="SetWindowState" />
+                <CategoryReference Kind="AssemblyCategory" Name="Form" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="Ner8auQSjKYNil6mPPEuSN" Name="Input" Kind="StateInputPin" />
+              <Pin Id="UDtyYVLXCtBOkwYiQ5I4m1" Name="Value" Kind="InputPin" DefaultValue="Maximized">
+                <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                  <Choice Kind="TypeFlag" Name="FormWindowState" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="Vwqw4A2cjueN2CSHoOuEw0" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="Dp2aLEf0xlFMWRJingvFnH" Name="Apply" Kind="InputPin" />
+            </Node>
+            <ControlPoint Id="Nkbf9sV46OoMY7cEznZLF8" Bounds="425,464" />
+            <ControlPoint Id="JgE9yL4B33DLXQ9wuD0rmp" Bounds="425,542" />
+            <ControlPoint Id="M6m0yHWs445O7r7MtdxCtF" Bounds="508,468" />
+          </Canvas>
+          <Patch Id="TZSp9CFmUijPbFbM6gFqdw" Name="Create" />
+          <Patch Id="PZdYUGPmNtvPHAzbZHp8Uz" Name="Update">
+            <Pin Id="PfBquHsiY8XNsYRZ6O2NsO" Name="Input" Kind="InputPin" Bounds="428,464">
+              <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="TypeFlag" Name="Form" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="T75gCpKXXPFP2EQ9lhnkJC" Name="Output" Kind="OutputPin" Bounds="415,565">
+              <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="TypeFlag" Name="Form" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="NEYbGDJ7vuLMS6qMcVTmat" Name="Minimize" Kind="InputPin" Bounds="516,469" DefaultValue="False">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+          </Patch>
+          <ProcessDefinition Id="JgtW2uKqTD0M6D1ET6YRxK">
+            <Fragment Id="FkF96IKZ7rdPe4iwqStCQq" Patch="TZSp9CFmUijPbFbM6gFqdw" Enabled="true" />
+            <Fragment Id="DKjlH9K6quEOvwgWoKRgTD" Patch="PZdYUGPmNtvPHAzbZHp8Uz" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="BYSJIAjwyqmMBdUZsTqcHa" Ids="Nkbf9sV46OoMY7cEznZLF8,Ner8auQSjKYNil6mPPEuSN" />
+          <Link Id="P48p7pkSGmoP5mM8b4DriT" Ids="PfBquHsiY8XNsYRZ6O2NsO,Nkbf9sV46OoMY7cEznZLF8" IsHidden="true" />
+          <Link Id="K1UNPKoOYohOtpF5xTR84V" Ids="Vwqw4A2cjueN2CSHoOuEw0,JgE9yL4B33DLXQ9wuD0rmp" />
+          <Link Id="PnOJSxnmW0xOmwy6PGJSTm" Ids="JgE9yL4B33DLXQ9wuD0rmp,T75gCpKXXPFP2EQ9lhnkJC" IsHidden="true" />
+          <Link Id="RY4LL3h7BwPPjo7QNBhxnH" Ids="M6m0yHWs445O7r7MtdxCtF,Dp2aLEf0xlFMWRJingvFnH" />
+          <Link Id="AnKVsW2KHFhNA05ZZCvSCL" Ids="NEYbGDJ7vuLMS6qMcVTmat,M6m0yHWs445O7r7MtdxCtF" IsHidden="true" />
+        </Patch>
+      </Node>
     </Canvas>
     <!--
 
@@ -2945,8 +3837,9 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="AaU1OkNBV4WNB7I5bEsHM0" Location="VL.Skia" Version="2020.1.0" />
+  <NugetDependency Id="AaU1OkNBV4WNB7I5bEsHM0" Location="VL.Skia" Version="2020.1.2" />
   <PlatformDependency Id="GZpVQMiqZIjOqMJP28OgAN" Location="System.Windows.Forms" />
   <PlatformDependency Id="ISjMipMy2cVOenuuHYkSlH" Location="System.ComponentModel" />
   <PlatformDependency Id="HfEo5Htsr04OweG5fkrazY" Location="System.Drawing" />
+  <PlatformDependency Id="ApcQM9rfmKrPT0wTSlqBxb" Location="System.Reflection" />
 </Document>

--- a/help/Notifications/HowTo Create a system tray icon.vl
+++ b/help/Notifications/HowTo Create a system tray icon.vl
@@ -15,12 +15,12 @@
       </p:NodeReference>
       <Patch Id="A8tXDxcVV0lMG4osoJwrkz">
         <Canvas Id="O379wLvpVApLbFDBQHvo26" CanvasType="Group">
-          <Node Bounds="290,83,145,19" Id="HHUPtVUxAiwMYOxD7LgZBK">
+          <Node Bounds="142,125,145,19" Id="HHUPtVUxAiwMYOxD7LgZBK">
             <p:NodeReference LastCategoryFullName="Graphics.Skia" LastSymbolSource="VL.Skia.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Renderer" />
             </p:NodeReference>
-            <Pin Id="Lbj7du5CEHGP3r8C8wtbz3" Name="Bounds" Kind="InputPin" DefaultValue="1012, 505, 426, 202">
+            <Pin Id="Lbj7du5CEHGP3r8C8wtbz3" Name="Bounds" Kind="InputPin" DefaultValue="1206, 549, 569, 372">
               <p:TypeAnnotation LastCategoryFullName="System.Drawing" LastSymbolSource="System.Drawing.dll">
                 <Choice Kind="TypeFlag" Name="Rectangle" />
               </p:TypeAnnotation>
@@ -36,7 +36,7 @@
             <Pin Id="ESMf7ZL2xBgNuSj6y16mpd" Name="ClientBounds" Kind="OutputPin" />
             <Pin Id="Uma85d5qVtoMnloYV8r1vN" Name="Render Time" Kind="OutputPin" />
           </Node>
-          <Node Bounds="290,569,65,19" Id="K9nMtRNVgCAMRBwtKukTsE">
+          <Node Bounds="142,625,65,19" Id="K9nMtRNVgCAMRBwtKukTsE">
             <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="NotifyIcon" />
@@ -58,7 +58,7 @@
             <Pin Id="M2FbiAjTgJGNm1tVHXJVpM" Name="On Double Click" Kind="OutputPin" />
             <Pin Id="K3kYY2mblo0NowaFyo5XVi" Name="On Context Menu Items Click" Kind="OutputPin" />
           </Node>
-          <Node Bounds="290,222,81,19" Id="E0QSjjhCNXmMoniKkL556R">
+          <Node Bounds="142,279,81,19" Id="E0QSjjhCNXmMoniKkL556R">
             <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SetControlBox" />
@@ -71,7 +71,7 @@
             </Pin>
             <Pin Id="MzDrqy2uGe6MXJi1a7Kaoi" Name="Input" Kind="OutputPin" />
           </Node>
-          <Node Bounds="290,158,88,19" Id="VHqYiiqdDA9LGrozED1EnK">
+          <Node Bounds="142,215,88,19" Id="VHqYiiqdDA9LGrozED1EnK">
             <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SetMinimizeBox" />
@@ -84,7 +84,7 @@
             </Pin>
             <Pin Id="AF7koJdvYHEO7Of9vqCMc3" Name="Input" Kind="OutputPin" />
           </Node>
-          <Node Bounds="290,190,91,19" Id="ON5Km3NvCRoP4gJvJvjpKz">
+          <Node Bounds="142,247,91,19" Id="ON5Km3NvCRoP4gJvJvjpKz">
             <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SetMaximizeBox" />
@@ -97,7 +97,7 @@
             </Pin>
             <Pin Id="NbtxZkr6xOCQB0vwBIpLKz" Name="Input" Kind="OutputPin" />
           </Node>
-          <Node Bounds="290,126,81,19" Id="Ns6JTBzdXGWNFavfNesXoL">
+          <Node Bounds="142,183,81,19" Id="Ns6JTBzdXGWNFavfNesXoL">
             <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SetBorderStyle" />
@@ -110,7 +110,7 @@
             </Pin>
             <Pin Id="RxZt1xFL7wqLxdP3ce7CmE" Name="Input" Kind="OutputPin" />
           </Node>
-          <Node Bounds="265,832,77,86" Id="GgZJMTKLLTdN7GZOdOoMaS">
+          <Node Bounds="115,851,77,86" Id="GgZJMTKLLTdN7GZOdOoMaS">
             <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
               <Choice Kind="ProcessAppFlag" Name="ForEach" />
               <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -129,9 +129,9 @@
                   </p:TypeAnnotation>
                 </Pin>
               </Patch>
-              <ControlPoint Id="HynwLroUnSQONzea1dBlwM" Bounds="269,840" />
-              <ControlPoint Id="QfshgYr8LLeLevEjF6NdC3" Bounds="295,911" />
-              <Node Bounds="290,870,40,19" Id="C3Hw4eU04zzLoMYFqqFJJh">
+              <ControlPoint Id="HynwLroUnSQONzea1dBlwM" Bounds="119,859" />
+              <ControlPoint Id="QfshgYr8LLeLevEjF6NdC3" Bounds="145,930" />
+              <Node Bounds="140,889,40,19" Id="C3Hw4eU04zzLoMYFqqFJJh">
                 <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="Show" />
@@ -146,7 +146,7 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="L32PbAogxcCM0BDEvdqhfJ" Comment="Context Menu Items" Bounds="352,413,75,65" ShowValueBox="true" isIOBox="true">
+          <Pad Id="L32PbAogxcCM0BDEvdqhfJ" Comment="Context Menu Items" Bounds="204,470,75,65" ShowValueBox="true" isIOBox="true">
             <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
               <Choice Kind="TypeFlag" Name="Spread" />
               <p:TypeArguments>
@@ -161,7 +161,7 @@
               <Item>Item 03</Item>
             </p:Value>
           </Pad>
-          <Pad Id="UFQ0Chl2vndOGta5WUQlqL" Bounds="370,549,247,78" ShowValueBox="true" isIOBox="true" Value="This guy will add an icon to your system tray. By default, it uses you app's icon and only shows up when the attached Renderer is minimized.">
+          <Pad Id="UFQ0Chl2vndOGta5WUQlqL" Bounds="221,598,247,78" ShowValueBox="true" isIOBox="true" Value="This guy will add an icon to your system tray. By default, it uses you app's icon and only shows up when the attached Renderer is minimized.">
             <p:TypeAnnotation>
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -170,7 +170,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="M8hHbS4P2izPTBrXAeQqa7" Bounds="440,436,210,62" ShowValueBox="true" isIOBox="true" Value="Those items will be displayed as a small context menu when right-clicking your systray icon">
+          <Pad Id="M8hHbS4P2izPTBrXAeQqa7" Bounds="292,493,200,60" ShowValueBox="true" isIOBox="true" Value="Those items will be displayed as a small context menu when right-clicking your systray icon">
             <p:TypeAnnotation>
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -179,7 +179,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="BA0B8IIXbrjMIp39QRrd40" Bounds="351,862,204,62" ShowValueBox="true" isIOBox="true" Value="Here, we show the attached Renderer when its notify-icon is double-clicked.">
+          <Pad Id="BA0B8IIXbrjMIp39QRrd40" Bounds="201,877,204,62" ShowValueBox="true" isIOBox="true" Value="Here, we show the attached Renderer when its notify-icon is double-clicked.">
             <p:TypeAnnotation>
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -188,7 +188,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Node Bounds="350,683,50,19" Id="OyLtsDBWimJOvPg3w73qvY">
+          <Node Bounds="202,729,50,19" Id="OyLtsDBWimJOvPg3w73qvY">
             <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="Decons" />
@@ -199,8 +199,8 @@
             <Pin Id="BQIjfULBu2OP4dAJxYXZPB" Name="Result 2" Kind="OutputPin" />
             <Pin Id="R73Vi7NJe0SPQBWfDlxtkl" Name="Result 3" Kind="OutputPin" />
           </Node>
-          <Pad Id="H3ACPhNEZjZMFC9mlJuRGH" Bounds="406,688,214,64" ShowValueBox="true" isIOBox="true" Value="For each element of the context menu, you get an observable that fires when it's clicked.">
-            <p:TypeAnnotation>
+          <Pad Id="H3ACPhNEZjZMFC9mlJuRGH" Bounds="258,717,214,64" ShowValueBox="true" isIOBox="true" Value="For each item of the context menu (2.), you get an observable that fires when said item is clicked.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -208,10 +208,11 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Overlay Id="HBGhRZZcbzyPPrH03x4hHc" Name="" Bounds="329,372,346,127" />
-          <Overlay Id="GwTCCM1QuwmNWZM0u9FGOF" Name="" Bounds="215,776,370,146" />
-          <Overlay Id="UloudQDVQqXPnpDTm2nI8Q" Name="" Bounds="328,668,327,95" />
-          <Node Bounds="310,46,105,19" Id="Hgv4JRRcV4OPyFvHozruj6">
+          <Overlay Id="HBGhRZZcbzyPPrH03x4hHc" Name="" Bounds="181,442,327,110">
+            <p:ColorIndex p:Type="Int32">3</p:ColorIndex>
+          </Overlay>
+          <Overlay Id="GwTCCM1QuwmNWZM0u9FGOF" Name="" Bounds="64,820,370,141" />
+          <Node Bounds="162,88,105,19" Id="Hgv4JRRcV4OPyFvHozruj6">
             <p:NodeReference LastCategoryFullName="Graphics.Skia.Layers.Text" LastSymbolSource="VL.Skia.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Text" />
@@ -229,7 +230,7 @@
             <Pin Id="Dwa0A3iw0C9L8HvwMKOJPl" Name="Output" Kind="OutputPin" />
             <Pin Id="T3fzHPQyl1QNxEtXRb914q" Name="Baseline Position" Kind="OutputPin" />
           </Node>
-          <Node Bounds="290,307,73,19" Id="BiS2LnS6seiOnNTDwCw9t1">
+          <Node Bounds="142,364,73,19" Id="BiS2LnS6seiOnNTDwCw9t1">
             <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SetShowIcon" />
@@ -243,7 +244,7 @@
             </Pin>
             <Pin Id="P6P8R2Uy6RVQamOV6AOT61" Name="Input" Kind="OutputPin" />
           </Node>
-          <Node Bounds="290,274,49,19" Id="D7ps4RTj3OLLyNTRnt4UOs">
+          <Node Bounds="142,331,49,19" Id="D7ps4RTj3OLLyNTRnt4UOs">
             <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SetIcon" />
@@ -257,15 +258,78 @@
             </Pin>
             <Pin Id="S445vc9G6c3NHn7DzszHye" Name="Input" Kind="OutputPin" />
           </Node>
-          <Pad Id="F8V78diSrE1MZqFuHUV8yp" Comment="Icon" Bounds="336,262,157,15" ShowValueBox="true" isIOBox="true" Value="..\Window\green.png">
+          <Pad Id="F8V78diSrE1MZqFuHUV8yp" Comment="Icon" Bounds="188,319,157,15" ShowValueBox="true" isIOBox="true" Value="..\Window\red.png">
             <p:TypeAnnotation LastCategoryFullName="IO" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Path" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="KMQGcFoYZDHNema8EJtE01" Comment="Show Icon" Bounds="360,297,35,15" ShowValueBox="true" isIOBox="true" Value="True">
+          <Pad Id="KMQGcFoYZDHNema8EJtE01" Comment="Show Icon" Bounds="212,354,35,15" ShowValueBox="true" isIOBox="true" Value="True">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Boolean" />
             </p:TypeAnnotation>
+          </Pad>
+          <Overlay Id="E4rXeKeQYDJK90CltGjXzU" Name="" Bounds="127,172,400,227">
+            <p:ColorIndex p:Type="Int32">1</p:ColorIndex>
+          </Overlay>
+          <Pad Id="I9FNuIVbnyaMYBAjOT9j1e" Bounds="405,191,101,19" ShowValueBox="true" isIOBox="true" Value="Renderer setup">
+            <p:TypeAnnotation>
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Overlay Id="Nwb2B6GUUNTOB9b4Mc51Wy" Name="" Bounds="109,582,633,97">
+            <p:ColorIndex p:Type="Int32">5</p:ColorIndex>
+          </Overlay>
+          <Overlay Id="R2aNfz9UvnQOJReBHfNVzW" Name="" Bounds="180,698,328,88">
+            <p:ColorIndex p:Type="Int32">3</p:ColorIndex>
+          </Overlay>
+          <Pad Id="HxBMHkN5Rf2LPKgyJEglmt" Bounds="48,629,35,27" ShowValueBox="true" isIOBox="true" Value="1.">
+            <p:TypeAnnotation>
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">13</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="PxrK9mO6EfjNVdBSBDKPs3" Bounds="48,477,35,27" ShowValueBox="true" isIOBox="true" Value="2.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">13</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="NhjIZ7hBfUNNxVzej30uaz" Bounds="48,733,35,27" ShowValueBox="true" isIOBox="true" Value="3.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">13</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="MxsOhxjTCW5NNBTQogHhVl" Bounds="480,598,247,78" ShowValueBox="true" isIOBox="true" Value="It also outputs a bunch of observables that fire when the systray icon is interacted : mouse click, double click, etc. Right clic/configure to enable those.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="Jo0cysWRdhDPpUkilcqEKt" Bounds="10,884,35,27" ShowValueBox="true" isIOBox="true" Value="4.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">13</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
           </Pad>
         </Canvas>
         <Patch Id="BnA2SfGRGsXOVyMLku1hoK" Name="Create" />
@@ -285,11 +349,11 @@
         <Link Id="IXKyzEWIA9kN86Cnv0uNUR" Ids="LP8q8EZnx4dQTM8f4PsQjW,Ny70K1t7v0ULZxN3mYW3CT" />
         <Link Id="PfJybHCQsMyPUFnAyksacM" Ids="K3kYY2mblo0NowaFyo5XVi,DBbILzQzQVrLcsvJswO4Wd" />
         <Link Id="UehyONVIRhQMCdzHHLERZn" Ids="Dwa0A3iw0C9L8HvwMKOJPl,JjsNzf8zbeQO3vaEahhWlf" />
-        <Link Id="KMjfX0n49ouNZaFTX6b494" Ids="S445vc9G6c3NHn7DzszHye,BCiYaOraOSTLSrDycRmImF" />
         <Link Id="MVqdWFAE6ZPMFSJRu7j5mA" Ids="KMQGcFoYZDHNema8EJtE01,S9BO2L83vWLNZRL8CLVBfp" />
         <Link Id="GS3k94LMgyVMFAQOYrAcf0" Ids="MzDrqy2uGe6MXJi1a7Kaoi,EtlC0IN31quLrK7wy1uOP5" />
         <Link Id="H0bqppSpxvjLWZhc7ZuXV1" Ids="P6P8R2Uy6RVQamOV6AOT61,EdzYoOvLchFLEtGBjJ6Cr8" />
         <Link Id="G5IgSozzTxDMjFzpsK2HnJ" Ids="F8V78diSrE1MZqFuHUV8yp,GDlnh9OuNWxLREHzmTOvDG" />
+        <Link Id="TVrC3Fk7mM7PadwkNF5K1P" Ids="S445vc9G6c3NHn7DzszHye,BCiYaOraOSTLSrDycRmImF" />
       </Patch>
     </Node>
   </Patch>

--- a/help/Notifications/HowTo Create a system tray icon.vl
+++ b/help/Notifications/HowTo Create a system tray icon.vl
@@ -1,0 +1,256 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" Id="O8PxipeFXaHPaNZp6Z1i5D" LanguageVersion="2020.1.2.135" Version="0.128">
+  <NugetDependency Id="SPEVC7UEYp1MloVgtTNHc4" Location="VL.CoreLib" Version="2020.1.2" />
+  <Patch Id="GJqFL2AbYyoM3DlXfgTfyN">
+    <Canvas Id="IkGdSMRx9iXM9iLIldlOHH" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="KX7iPJZUrEULj4POP1h1lh">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="A8tXDxcVV0lMG4osoJwrkz">
+        <Canvas Id="O379wLvpVApLbFDBQHvo26" CanvasType="Group">
+          <Node Bounds="290,143,145,19" Id="HHUPtVUxAiwMYOxD7LgZBK">
+            <p:NodeReference LastCategoryFullName="Graphics.Skia" LastSymbolSource="VL.Skia.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="Renderer" />
+            </p:NodeReference>
+            <Pin Id="Lbj7du5CEHGP3r8C8wtbz3" Name="Bounds" Kind="InputPin" DefaultValue="-32000, -32000, 160, 28">
+              <p:TypeAnnotation LastCategoryFullName="System.Drawing" LastSymbolSource="System.Drawing.dll">
+                <Choice Kind="TypeFlag" Name="Rectangle" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="JjsNzf8zbeQO3vaEahhWlf" Name="Input" Kind="InputPin" />
+            <Pin Id="R4DZTgaXbXiMDUNMuJHmeY" Name="Color" Kind="InputPin" />
+            <Pin Id="HLqKD52KSeTO2zBgLn8j9P" Name="Clear" Kind="InputPin" />
+            <Pin Id="GKPYsEBwOMQMTTEKOYrFSR" Name="Space" Kind="InputPin" />
+            <Pin Id="S0rqL8rt0gpPUMcTy6EqO6" Name="Show Cursor" Kind="InputPin" />
+            <Pin Id="G6rxTpc0rSDLtx3swqypLy" Name="VSync" Kind="InputPin" />
+            <Pin Id="MDdhTZSOVZYMEAwN8OODM5" Name="Enabled" Kind="InputPin" />
+            <Pin Id="LP8q8EZnx4dQTM8f4PsQjW" Name="Form" Kind="OutputPin" />
+            <Pin Id="ESMf7ZL2xBgNuSj6y16mpd" Name="ClientBounds" Kind="OutputPin" />
+            <Pin Id="Uma85d5qVtoMnloYV8r1vN" Name="Render Time" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="290,509,65,19" Id="K9nMtRNVgCAMRBwtKukTsE">
+            <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="NotifyIcon" />
+            </p:NodeReference>
+            <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">High</p:HelpFocus>
+            <Pin Id="EdzYoOvLchFLEtGBjJ6Cr8" Name="Input" Kind="InputPin" />
+            <Pin Id="BzurcFM7hEDQb82iTOTxW2" Name="Show When Minimized" Kind="InputPin">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="RYXQigIn1PCLKGbuEO8miu" Name="Text" Kind="InputPin">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="SRjelAeszPVQSTO9kFwitW" Name="Context Menu Items" Kind="InputPin" />
+            <Pin Id="BrINQXxFWvHMDPvrNb8EZf" Name="Output" Kind="OutputPin" />
+            <Pin Id="M2FbiAjTgJGNm1tVHXJVpM" Name="On Double Click" Kind="OutputPin" />
+            <Pin Id="K3kYY2mblo0NowaFyo5XVi" Name="On Context Menu Items Click" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="290,282,81,19" Id="E0QSjjhCNXmMoniKkL556R">
+            <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="SetControlBox" />
+            </p:NodeReference>
+            <Pin Id="NaNIEaRJYBkO13UsKVb4JE" Name="Input" Kind="InputPin" />
+            <Pin Id="M1wDaeawH0yPjVWONRIpJF" Name="Show Control Box" Kind="InputPin" DefaultValue="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="MzDrqy2uGe6MXJi1a7Kaoi" Name="Input" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="290,218,88,19" Id="VHqYiiqdDA9LGrozED1EnK">
+            <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="SetMinimizeBox" />
+            </p:NodeReference>
+            <Pin Id="MMqX4woaibINrXtYisKKlW" Name="Input" Kind="InputPin" />
+            <Pin Id="A9wpPbtjxckLtWm5LEmiUo" Name="Show Minimize Box" Kind="InputPin" DefaultValue="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="AF7koJdvYHEO7Of9vqCMc3" Name="Input" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="290,250,91,19" Id="ON5Km3NvCRoP4gJvJvjpKz">
+            <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="SetMaximizeBox" />
+            </p:NodeReference>
+            <Pin Id="TL0tW7gww3ZLAIdndXJbej" Name="Input" Kind="InputPin" />
+            <Pin Id="BGHMHZJaJwkQTqMoA9JnJB" Name="Show Maximize Box" Kind="InputPin" DefaultValue="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="NbtxZkr6xOCQB0vwBIpLKz" Name="Input" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="290,186,81,19" Id="Ns6JTBzdXGWNFavfNesXoL">
+            <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="SetBorderStyle" />
+            </p:NodeReference>
+            <Pin Id="Ny70K1t7v0ULZxN3mYW3CT" Name="Input" Kind="InputPin" />
+            <Pin Id="TjDPfNmwo6fMWxj0elkTv7" Name="Border Style" Kind="InputPin" DefaultValue="Sizable">
+              <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+                <Choice Kind="TypeFlag" Name="FormBorderStyle" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="RxZt1xFL7wqLxdP3ce7CmE" Name="Input" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="265,772,77,86" Id="GgZJMTKLLTdN7GZOdOoMaS">
+            <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <Choice Kind="ProcessAppFlag" Name="ForEach" />
+              <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+              <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+            </p:NodeReference>
+            <Pin Id="HQyIiuxtaapM0xRZRZjN0A" Name="Messages" Kind="InputPin" />
+            <Pin Id="VUSHCt70QCXP6ETgG5ASOu" Name="Reset" Kind="InputPin" />
+            <Pin Id="FZhabe7WfTsP1D93NXtOD9" Name="Result" Kind="OutputPin" />
+            <Patch Id="Is04MWmTAiLP1oqOEXSWI9" ManuallySortedPins="true">
+              <Patch Id="Qo5KBOM0YRlNfwc8vtg7wk" Name="Create" ManuallySortedPins="true" />
+              <Patch Id="QbKDHSiiIU4L6JO75zCHDg" Name="Update" ManuallySortedPins="true">
+                <Pin Id="GP3zBE4Eb2mPRj4MM4xdv1" Name="Input 1" Kind="InputPin" />
+                <Pin Id="GDpRhyByDufM0yYuydUYvl" Name="Output" Kind="OutputPin">
+                  <p:TypeAnnotation>
+                    <Choice Kind="TypeFlag" Name="Boolean" />
+                  </p:TypeAnnotation>
+                </Pin>
+              </Patch>
+              <ControlPoint Id="HynwLroUnSQONzea1dBlwM" Bounds="269,780" />
+              <ControlPoint Id="QfshgYr8LLeLevEjF6NdC3" Bounds="295,851" />
+              <Node Bounds="290,810,40,19" Id="C3Hw4eU04zzLoMYFqqFJJh">
+                <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="Show" />
+                </p:NodeReference>
+                <Pin Id="MIGc67EfLXbLVsPzWmZxL6" Name="Input" Kind="InputPin" />
+                <Pin Id="FUtNyiUdsOVLOk2aqJ453S" Name="Show" Kind="InputPin" DefaultValue="True">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="Boolean" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="R2E9Vc1SzfBPmHJOEtfeAG" Name="Output" Kind="OutputPin" />
+              </Node>
+            </Patch>
+          </Node>
+          <Pad Id="L32PbAogxcCM0BDEvdqhfJ" Comment="Context Menu Items" Bounds="352,353,75,65" ShowValueBox="true" isIOBox="true">
+            <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+              <Choice Kind="TypeFlag" Name="Spread" />
+              <p:TypeArguments>
+                <TypeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </TypeReference>
+              </p:TypeArguments>
+            </p:TypeAnnotation>
+            <p:Value>
+              <Item>Item 01</Item>
+              <Item>Item 02</Item>
+              <Item>Item 03</Item>
+            </p:Value>
+          </Pad>
+          <Pad Id="UFQ0Chl2vndOGta5WUQlqL" Bounds="370,489,247,78" ShowValueBox="true" isIOBox="true" Value="This guy will add an icon to your system tray. By default, it uses you app's icon and only shows up when the attached Renderer is minimized.">
+            <p:TypeAnnotation>
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="M8hHbS4P2izPTBrXAeQqa7" Bounds="440,376,210,62" ShowValueBox="true" isIOBox="true" Value="Those items will be displayed as a small context menu when right-clicking your systray icon">
+            <p:TypeAnnotation>
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="BA0B8IIXbrjMIp39QRrd40" Bounds="351,802,204,62" ShowValueBox="true" isIOBox="true" Value="Here, we show the attached Renderer when its notify-icon is double-clicked.">
+            <p:TypeAnnotation>
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Node Bounds="350,623,50,19" Id="OyLtsDBWimJOvPg3w73qvY">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="Decons" />
+              <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
+            </p:NodeReference>
+            <Pin Id="DBbILzQzQVrLcsvJswO4Wd" Name="Input" Kind="StateInputPin" />
+            <Pin Id="KvGngYqhU5YMDPJOKRHyyJ" Name="Result" Kind="OutputPin" />
+            <Pin Id="BQIjfULBu2OP4dAJxYXZPB" Name="Result 2" Kind="OutputPin" />
+            <Pin Id="R73Vi7NJe0SPQBWfDlxtkl" Name="Result 3" Kind="OutputPin" />
+          </Node>
+          <Pad Id="H3ACPhNEZjZMFC9mlJuRGH" Bounds="406,628,214,64" ShowValueBox="true" isIOBox="true" Value="For each element of the context menu, you get an observable that fires when it's clicked.">
+            <p:TypeAnnotation>
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Overlay Id="HBGhRZZcbzyPPrH03x4hHc" Name="" Bounds="329,312,346,127" />
+          <Overlay Id="GwTCCM1QuwmNWZM0u9FGOF" Name="" Bounds="215,716,370,146" />
+          <Overlay Id="UloudQDVQqXPnpDTm2nI8Q" Name="" Bounds="328,608,327,95" />
+          <Node Bounds="310,106,105,19" Id="Hgv4JRRcV4OPyFvHozruj6">
+            <p:NodeReference LastCategoryFullName="Graphics.Skia.Layers.Text" LastSymbolSource="VL.Skia.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="Text" />
+            </p:NodeReference>
+            <Pin Id="M4ga00XshhyOFaiQzBOVnx" Name="Position" Kind="InputPin" />
+            <Pin Id="ByD90NzarN7OLcij9o4JEk" Name="Size" Kind="InputPin" />
+            <Pin Id="QMBXX1IdiGbLtnTfZnLj7t" Name="Anchor" Kind="InputPin" />
+            <Pin Id="A75gJdr9rRZO3m2O6Jxpyw" Name="Text" Kind="InputPin" DefaultValue="Minimize me and check your system tray!&#xD;&#xA;&#xD;&#xA;Double-click the notify icon to bring me back.">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="MEbXEBkRLtcLH02k0rCLgn" Name="Paint" Kind="InputPin" />
+            <Pin Id="MwjCL7rcmB9MHDKyQGtwxI" Name="Enabled" Kind="InputPin" />
+            <Pin Id="Dwa0A3iw0C9L8HvwMKOJPl" Name="Output" Kind="OutputPin" />
+            <Pin Id="T3fzHPQyl1QNxEtXRb914q" Name="Baseline Position" Kind="OutputPin" />
+          </Node>
+        </Canvas>
+        <Patch Id="BnA2SfGRGsXOVyMLku1hoK" Name="Create" />
+        <Patch Id="EUbD8hpWaXOLL5bSs1hRAp" Name="Update" />
+        <ProcessDefinition Id="FXPpA6tIvDINzGFpSFf2oq">
+          <Fragment Id="U3wWPFWwGRSPEStePDBCBf" Patch="BnA2SfGRGsXOVyMLku1hoK" Enabled="true" />
+          <Fragment Id="ENlYsNbzDLaOrBRmASRBjr" Patch="EUbD8hpWaXOLL5bSs1hRAp" Enabled="true" />
+        </ProcessDefinition>
+        <Link Id="ARHiofWl5IbOm1yCi3MbCN" Ids="NbtxZkr6xOCQB0vwBIpLKz,NaNIEaRJYBkO13UsKVb4JE" />
+        <Link Id="B8YQJ4zDdOcQQjkfmc4AzL" Ids="AF7koJdvYHEO7Of9vqCMc3,TL0tW7gww3ZLAIdndXJbej" />
+        <Link Id="Q4Ycresf1juPt2rw5m3tp7" Ids="RxZt1xFL7wqLxdP3ce7CmE,MMqX4woaibINrXtYisKKlW" />
+        <Link Id="QT8KzHuB4PMMrTqlKeMfMj" Ids="MzDrqy2uGe6MXJi1a7Kaoi,EdzYoOvLchFLEtGBjJ6Cr8" />
+        <Link Id="BEvCPpcR2CZPiV6LSvdnFq" Ids="GP3zBE4Eb2mPRj4MM4xdv1,HynwLroUnSQONzea1dBlwM" IsHidden="true" />
+        <Link Id="GtvPdzqN8oRPnH9Ars9ktE" Ids="QfshgYr8LLeLevEjF6NdC3,GDpRhyByDufM0yYuydUYvl" IsHidden="true" />
+        <Link Id="I3Y1Y3hG2lALbOMAYxaGOC" Ids="BrINQXxFWvHMDPvrNb8EZf,MIGc67EfLXbLVsPzWmZxL6" />
+        <Link Id="NZspnXzf4stQROtEGxSrIG" Ids="M2FbiAjTgJGNm1tVHXJVpM,HQyIiuxtaapM0xRZRZjN0A" />
+        <Link Id="Qo5KGMqiCwJOt2wBQyqLyT" Ids="L32PbAogxcCM0BDEvdqhfJ,SRjelAeszPVQSTO9kFwitW" />
+        <Link Id="IXKyzEWIA9kN86Cnv0uNUR" Ids="LP8q8EZnx4dQTM8f4PsQjW,Ny70K1t7v0ULZxN3mYW3CT" />
+        <Link Id="PfJybHCQsMyPUFnAyksacM" Ids="K3kYY2mblo0NowaFyo5XVi,DBbILzQzQVrLcsvJswO4Wd" />
+        <Link Id="UehyONVIRhQMCdzHHLERZn" Ids="Dwa0A3iw0C9L8HvwMKOJPl,JjsNzf8zbeQO3vaEahhWlf" />
+      </Patch>
+    </Node>
+  </Patch>
+  <NugetDependency Id="SvtrnHcc5lmLl3QmFPLj04" Location="VL.Skia" Version="2020.1.2" />
+  <NugetDependency Id="ABW2Wpdbx2aMt7GQs9wbQp" Location="VL.WinFormsUtils" Version="0.0.0.0" />
+</Document>

--- a/help/Notifications/HowTo Create a system tray icon.vl
+++ b/help/Notifications/HowTo Create a system tray icon.vl
@@ -15,12 +15,12 @@
       </p:NodeReference>
       <Patch Id="A8tXDxcVV0lMG4osoJwrkz">
         <Canvas Id="O379wLvpVApLbFDBQHvo26" CanvasType="Group">
-          <Node Bounds="290,143,145,19" Id="HHUPtVUxAiwMYOxD7LgZBK">
+          <Node Bounds="290,83,145,19" Id="HHUPtVUxAiwMYOxD7LgZBK">
             <p:NodeReference LastCategoryFullName="Graphics.Skia" LastSymbolSource="VL.Skia.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Renderer" />
             </p:NodeReference>
-            <Pin Id="Lbj7du5CEHGP3r8C8wtbz3" Name="Bounds" Kind="InputPin" DefaultValue="-32000, -32000, 160, 28">
+            <Pin Id="Lbj7du5CEHGP3r8C8wtbz3" Name="Bounds" Kind="InputPin" DefaultValue="1012, 505, 426, 202">
               <p:TypeAnnotation LastCategoryFullName="System.Drawing" LastSymbolSource="System.Drawing.dll">
                 <Choice Kind="TypeFlag" Name="Rectangle" />
               </p:TypeAnnotation>
@@ -36,7 +36,7 @@
             <Pin Id="ESMf7ZL2xBgNuSj6y16mpd" Name="ClientBounds" Kind="OutputPin" />
             <Pin Id="Uma85d5qVtoMnloYV8r1vN" Name="Render Time" Kind="OutputPin" />
           </Node>
-          <Node Bounds="290,509,65,19" Id="K9nMtRNVgCAMRBwtKukTsE">
+          <Node Bounds="290,569,65,19" Id="K9nMtRNVgCAMRBwtKukTsE">
             <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="NotifyIcon" />
@@ -58,7 +58,7 @@
             <Pin Id="M2FbiAjTgJGNm1tVHXJVpM" Name="On Double Click" Kind="OutputPin" />
             <Pin Id="K3kYY2mblo0NowaFyo5XVi" Name="On Context Menu Items Click" Kind="OutputPin" />
           </Node>
-          <Node Bounds="290,282,81,19" Id="E0QSjjhCNXmMoniKkL556R">
+          <Node Bounds="290,222,81,19" Id="E0QSjjhCNXmMoniKkL556R">
             <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SetControlBox" />
@@ -71,7 +71,7 @@
             </Pin>
             <Pin Id="MzDrqy2uGe6MXJi1a7Kaoi" Name="Input" Kind="OutputPin" />
           </Node>
-          <Node Bounds="290,218,88,19" Id="VHqYiiqdDA9LGrozED1EnK">
+          <Node Bounds="290,158,88,19" Id="VHqYiiqdDA9LGrozED1EnK">
             <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SetMinimizeBox" />
@@ -84,7 +84,7 @@
             </Pin>
             <Pin Id="AF7koJdvYHEO7Of9vqCMc3" Name="Input" Kind="OutputPin" />
           </Node>
-          <Node Bounds="290,250,91,19" Id="ON5Km3NvCRoP4gJvJvjpKz">
+          <Node Bounds="290,190,91,19" Id="ON5Km3NvCRoP4gJvJvjpKz">
             <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SetMaximizeBox" />
@@ -97,7 +97,7 @@
             </Pin>
             <Pin Id="NbtxZkr6xOCQB0vwBIpLKz" Name="Input" Kind="OutputPin" />
           </Node>
-          <Node Bounds="290,186,81,19" Id="Ns6JTBzdXGWNFavfNesXoL">
+          <Node Bounds="290,126,81,19" Id="Ns6JTBzdXGWNFavfNesXoL">
             <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SetBorderStyle" />
@@ -110,7 +110,7 @@
             </Pin>
             <Pin Id="RxZt1xFL7wqLxdP3ce7CmE" Name="Input" Kind="OutputPin" />
           </Node>
-          <Node Bounds="265,772,77,86" Id="GgZJMTKLLTdN7GZOdOoMaS">
+          <Node Bounds="265,832,77,86" Id="GgZJMTKLLTdN7GZOdOoMaS">
             <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
               <Choice Kind="ProcessAppFlag" Name="ForEach" />
               <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -129,9 +129,9 @@
                   </p:TypeAnnotation>
                 </Pin>
               </Patch>
-              <ControlPoint Id="HynwLroUnSQONzea1dBlwM" Bounds="269,780" />
-              <ControlPoint Id="QfshgYr8LLeLevEjF6NdC3" Bounds="295,851" />
-              <Node Bounds="290,810,40,19" Id="C3Hw4eU04zzLoMYFqqFJJh">
+              <ControlPoint Id="HynwLroUnSQONzea1dBlwM" Bounds="269,840" />
+              <ControlPoint Id="QfshgYr8LLeLevEjF6NdC3" Bounds="295,911" />
+              <Node Bounds="290,870,40,19" Id="C3Hw4eU04zzLoMYFqqFJJh">
                 <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="Show" />
@@ -146,7 +146,7 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="L32PbAogxcCM0BDEvdqhfJ" Comment="Context Menu Items" Bounds="352,353,75,65" ShowValueBox="true" isIOBox="true">
+          <Pad Id="L32PbAogxcCM0BDEvdqhfJ" Comment="Context Menu Items" Bounds="352,413,75,65" ShowValueBox="true" isIOBox="true">
             <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
               <Choice Kind="TypeFlag" Name="Spread" />
               <p:TypeArguments>
@@ -161,7 +161,7 @@
               <Item>Item 03</Item>
             </p:Value>
           </Pad>
-          <Pad Id="UFQ0Chl2vndOGta5WUQlqL" Bounds="370,489,247,78" ShowValueBox="true" isIOBox="true" Value="This guy will add an icon to your system tray. By default, it uses you app's icon and only shows up when the attached Renderer is minimized.">
+          <Pad Id="UFQ0Chl2vndOGta5WUQlqL" Bounds="370,549,247,78" ShowValueBox="true" isIOBox="true" Value="This guy will add an icon to your system tray. By default, it uses you app's icon and only shows up when the attached Renderer is minimized.">
             <p:TypeAnnotation>
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -170,7 +170,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="M8hHbS4P2izPTBrXAeQqa7" Bounds="440,376,210,62" ShowValueBox="true" isIOBox="true" Value="Those items will be displayed as a small context menu when right-clicking your systray icon">
+          <Pad Id="M8hHbS4P2izPTBrXAeQqa7" Bounds="440,436,210,62" ShowValueBox="true" isIOBox="true" Value="Those items will be displayed as a small context menu when right-clicking your systray icon">
             <p:TypeAnnotation>
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -179,7 +179,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="BA0B8IIXbrjMIp39QRrd40" Bounds="351,802,204,62" ShowValueBox="true" isIOBox="true" Value="Here, we show the attached Renderer when its notify-icon is double-clicked.">
+          <Pad Id="BA0B8IIXbrjMIp39QRrd40" Bounds="351,862,204,62" ShowValueBox="true" isIOBox="true" Value="Here, we show the attached Renderer when its notify-icon is double-clicked.">
             <p:TypeAnnotation>
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -188,7 +188,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Node Bounds="350,623,50,19" Id="OyLtsDBWimJOvPg3w73qvY">
+          <Node Bounds="350,683,50,19" Id="OyLtsDBWimJOvPg3w73qvY">
             <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="Decons" />
@@ -199,7 +199,7 @@
             <Pin Id="BQIjfULBu2OP4dAJxYXZPB" Name="Result 2" Kind="OutputPin" />
             <Pin Id="R73Vi7NJe0SPQBWfDlxtkl" Name="Result 3" Kind="OutputPin" />
           </Node>
-          <Pad Id="H3ACPhNEZjZMFC9mlJuRGH" Bounds="406,628,214,64" ShowValueBox="true" isIOBox="true" Value="For each element of the context menu, you get an observable that fires when it's clicked.">
+          <Pad Id="H3ACPhNEZjZMFC9mlJuRGH" Bounds="406,688,214,64" ShowValueBox="true" isIOBox="true" Value="For each element of the context menu, you get an observable that fires when it's clicked.">
             <p:TypeAnnotation>
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -208,10 +208,10 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Overlay Id="HBGhRZZcbzyPPrH03x4hHc" Name="" Bounds="329,312,346,127" />
-          <Overlay Id="GwTCCM1QuwmNWZM0u9FGOF" Name="" Bounds="215,716,370,146" />
-          <Overlay Id="UloudQDVQqXPnpDTm2nI8Q" Name="" Bounds="328,608,327,95" />
-          <Node Bounds="310,106,105,19" Id="Hgv4JRRcV4OPyFvHozruj6">
+          <Overlay Id="HBGhRZZcbzyPPrH03x4hHc" Name="" Bounds="329,372,346,127" />
+          <Overlay Id="GwTCCM1QuwmNWZM0u9FGOF" Name="" Bounds="215,776,370,146" />
+          <Overlay Id="UloudQDVQqXPnpDTm2nI8Q" Name="" Bounds="328,668,327,95" />
+          <Node Bounds="310,46,105,19" Id="Hgv4JRRcV4OPyFvHozruj6">
             <p:NodeReference LastCategoryFullName="Graphics.Skia.Layers.Text" LastSymbolSource="VL.Skia.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Text" />
@@ -229,6 +229,44 @@
             <Pin Id="Dwa0A3iw0C9L8HvwMKOJPl" Name="Output" Kind="OutputPin" />
             <Pin Id="T3fzHPQyl1QNxEtXRb914q" Name="Baseline Position" Kind="OutputPin" />
           </Node>
+          <Node Bounds="290,307,73,19" Id="BiS2LnS6seiOnNTDwCw9t1">
+            <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="SetShowIcon" />
+            </p:NodeReference>
+            <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">High</p:HelpFocus>
+            <Pin Id="BCiYaOraOSTLSrDycRmImF" Name="Input" Kind="InputPin" />
+            <Pin Id="S9BO2L83vWLNZRL8CLVBfp" Name="Show Icon" Kind="InputPin" DefaultValue="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="P6P8R2Uy6RVQamOV6AOT61" Name="Input" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="290,274,49,19" Id="D7ps4RTj3OLLyNTRnt4UOs">
+            <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="SetIcon" />
+            </p:NodeReference>
+            <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">High</p:HelpFocus>
+            <Pin Id="EtlC0IN31quLrK7wy1uOP5" Name="Input" Kind="InputPin" />
+            <Pin Id="GDlnh9OuNWxLREHzmTOvDG" Name="Icon" Kind="InputPin" DefaultValue="..\..\Resources\SchemaLogo2-01.ico">
+              <p:TypeAnnotation LastCategoryFullName="IO" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Path" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="S445vc9G6c3NHn7DzszHye" Name="Input" Kind="OutputPin" />
+          </Node>
+          <Pad Id="F8V78diSrE1MZqFuHUV8yp" Comment="Icon" Bounds="336,262,157,15" ShowValueBox="true" isIOBox="true" Value="..\Window\green.png">
+            <p:TypeAnnotation LastCategoryFullName="IO" LastSymbolSource="CoreLibBasics.vl">
+              <Choice Kind="TypeFlag" Name="Path" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="KMQGcFoYZDHNema8EJtE01" Comment="Show Icon" Bounds="360,297,35,15" ShowValueBox="true" isIOBox="true" Value="True">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <Choice Kind="TypeFlag" Name="Boolean" />
+            </p:TypeAnnotation>
+          </Pad>
         </Canvas>
         <Patch Id="BnA2SfGRGsXOVyMLku1hoK" Name="Create" />
         <Patch Id="EUbD8hpWaXOLL5bSs1hRAp" Name="Update" />
@@ -239,7 +277,6 @@
         <Link Id="ARHiofWl5IbOm1yCi3MbCN" Ids="NbtxZkr6xOCQB0vwBIpLKz,NaNIEaRJYBkO13UsKVb4JE" />
         <Link Id="B8YQJ4zDdOcQQjkfmc4AzL" Ids="AF7koJdvYHEO7Of9vqCMc3,TL0tW7gww3ZLAIdndXJbej" />
         <Link Id="Q4Ycresf1juPt2rw5m3tp7" Ids="RxZt1xFL7wqLxdP3ce7CmE,MMqX4woaibINrXtYisKKlW" />
-        <Link Id="QT8KzHuB4PMMrTqlKeMfMj" Ids="MzDrqy2uGe6MXJi1a7Kaoi,EdzYoOvLchFLEtGBjJ6Cr8" />
         <Link Id="BEvCPpcR2CZPiV6LSvdnFq" Ids="GP3zBE4Eb2mPRj4MM4xdv1,HynwLroUnSQONzea1dBlwM" IsHidden="true" />
         <Link Id="GtvPdzqN8oRPnH9Ars9ktE" Ids="QfshgYr8LLeLevEjF6NdC3,GDpRhyByDufM0yYuydUYvl" IsHidden="true" />
         <Link Id="I3Y1Y3hG2lALbOMAYxaGOC" Ids="BrINQXxFWvHMDPvrNb8EZf,MIGc67EfLXbLVsPzWmZxL6" />
@@ -248,6 +285,11 @@
         <Link Id="IXKyzEWIA9kN86Cnv0uNUR" Ids="LP8q8EZnx4dQTM8f4PsQjW,Ny70K1t7v0ULZxN3mYW3CT" />
         <Link Id="PfJybHCQsMyPUFnAyksacM" Ids="K3kYY2mblo0NowaFyo5XVi,DBbILzQzQVrLcsvJswO4Wd" />
         <Link Id="UehyONVIRhQMCdzHHLERZn" Ids="Dwa0A3iw0C9L8HvwMKOJPl,JjsNzf8zbeQO3vaEahhWlf" />
+        <Link Id="KMjfX0n49ouNZaFTX6b494" Ids="S445vc9G6c3NHn7DzszHye,BCiYaOraOSTLSrDycRmImF" />
+        <Link Id="MVqdWFAE6ZPMFSJRu7j5mA" Ids="KMQGcFoYZDHNema8EJtE01,S9BO2L83vWLNZRL8CLVBfp" />
+        <Link Id="GS3k94LMgyVMFAQOYrAcf0" Ids="MzDrqy2uGe6MXJi1a7Kaoi,EtlC0IN31quLrK7wy1uOP5" />
+        <Link Id="H0bqppSpxvjLWZhc7ZuXV1" Ids="P6P8R2Uy6RVQamOV6AOT61,EdzYoOvLchFLEtGBjJ6Cr8" />
+        <Link Id="G5IgSozzTxDMjFzpsK2HnJ" Ids="F8V78diSrE1MZqFuHUV8yp,GDlnh9OuNWxLREHzmTOvDG" />
       </Patch>
     </Node>
   </Patch>

--- a/help/Notifications/HowTo Pop a notification balloon.vl
+++ b/help/Notifications/HowTo Pop a notification balloon.vl
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" Id="NO2sv8xzBnbLegUbe6HPJs" LanguageVersion="2020.1.2.135" Version="0.128">
+  <NugetDependency Id="TVZXREI2I6RMsmsMfNSmm6" Location="VL.CoreLib" Version="2020.1.2" />
+  <Patch Id="PS1gDKjJkNrOftwdpAbXze">
+    <Canvas Id="FQqMkJUYtdxQSWP1taw9DL" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="BzY4q7iV3gXL2mjEUMabzb">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="CzK5l7N4XKMNx7AD8igOdl">
+        <Canvas Id="AI4jtLfnzeiMafneqmAKJh" CanvasType="Group">
+          <Node Bounds="346,331" Id="BdCiKYrDcwkPKRxbpPJjXa">
+            <p:NodeReference LastCategoryFullName="Graphics.Skia" LastSymbolSource="VL.Skia.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="Renderer" />
+            </p:NodeReference>
+            <Pin Id="I8v8MClYnFfP588YcG7m2X" Name="Bounds" Kind="InputPin" DefaultValue="1179, 414, 600, 400">
+              <p:TypeAnnotation LastCategoryFullName="System.Drawing" LastSymbolSource="System.Drawing.dll">
+                <Choice Kind="TypeFlag" Name="Rectangle" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="DpBZhnl8Wv8NClC42EtEmQ" Name="Input" Kind="InputPin" />
+            <Pin Id="BnSh0HWDRItMDRT7mEm9dj" Name="Color" Kind="InputPin" />
+            <Pin Id="OiYd7KcEXRpP5Dl8Mhe6Nr" Name="Clear" Kind="InputPin" />
+            <Pin Id="DSdseUBtZRjMYe6qOAMWvI" Name="Space" Kind="InputPin" />
+            <Pin Id="Lv3GbWrMpmfNEoovfD1qfA" Name="Show Cursor" Kind="InputPin" />
+            <Pin Id="DpKc1B87QtaPxvwA0rcxDm" Name="VSync" Kind="InputPin" />
+            <Pin Id="FuMYFx1G0yhLqh1PRIUEvI" Name="Enabled" Kind="InputPin" />
+            <Pin Id="TDKRehgRiiqOgezK1IdT69" Name="Form" Kind="OutputPin" />
+            <Pin Id="Eu9GJnejR5MNZI5IxfhUaw" Name="ClientBounds" Kind="OutputPin" />
+            <Pin Id="GRnHV0qvZ3kLOyuCXDKxRX" Name="Render Time" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="346,674,286,19" Id="Oa1RxzGog7APQ2qtnZgxgV">
+            <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastSymbolSource="VL.WinFormsUtils.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="NotifyIcon" />
+            </p:NodeReference>
+            <Pin Id="M9QFUiHSSYUQKNm4272Fwi" Name="Input" Kind="InputPin" />
+            <Pin Id="KrRcXERwm1DMz9HLOn3xUE" Name="Force Show Notify Icon" Kind="InputPin" DefaultValue="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="L8waaYPjlJsOF9P0IT93Or" Name="Text" Kind="InputPin" />
+            <Pin Id="Juxu56PSEouNxe9y8II2x4" Name="Balloon Notification Title" Kind="InputPin" />
+            <Pin Id="UiN6hxODDqlOORNYnRx9EC" Name="Balloon Notification Text" Kind="InputPin" />
+            <Pin Id="P6Lcp5qNN0pO4swvL7KIFj" Name="Balloon Notification Icon" Kind="InputPin" />
+            <Pin Id="EFqPpzlQBdGPBdyk3PimBy" Name="Show Balloon Notification" Kind="InputPin" />
+            <Pin Id="BTro82VY20NNWvwdpoUgnM" Name="Context Menu Items" Kind="InputPin" />
+            <Pin Id="G7frb7aGF1JMYe5nDmsVya" Name="Output" Kind="OutputPin" />
+            <Pin Id="LgncKRLb62WLatI4AQ3iK8" Name="On Double Click" Kind="OutputPin" />
+            <Pin Id="H5vgDDrxoZUOlEITjYXSIi" Name="On Context Menu Items Click" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="366,217,85,19" Id="Q7MB2MmZl4LPOe4Uw2Thc2">
+            <p:NodeReference LastCategoryFullName="Graphics.Skia.Interaction" LastSymbolSource="VL.Skia.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="Button" />
+            </p:NodeReference>
+            <Pin Id="CUyZrv4WNYNLRoo8DIexUR" Name="Text" Kind="InputPin" DefaultValue="Click me &#xD;&#xA;to pop&#xD;&#xA;a notification">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="IZjJUG9oOsVPPWgOUDfTZA" Name="Bounds" Kind="InputPin" />
+            <Pin Id="LrClYPH8W0uO30SraSLtjV" Name="Paint" Kind="InputPin" />
+            <Pin Id="REwqVd4AY9HNgOGdL5NHPb" Name="Button" Kind="InputPin" />
+            <Pin Id="PcxmLMG9kc3OrCCS8L6hLx" Name="Clip" Kind="InputPin" />
+            <Pin Id="TKi5nklVjR1Pk04beuaaFN" Name="Output" Kind="OutputPin" />
+            <Pin Id="Q9lfQ5XiSZ2PmFpGodjD6o" Name="On Click" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="556,264,36,19" Id="Mo9cGrLFf2KOIB2NFjNnMJ">
+            <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="S+H" />
+              <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+            </p:NodeReference>
+            <Pin Id="FpWC3buV2w3QSB5t7gBKFn" Name="Async Notifications" Kind="InputPin" />
+            <Pin Id="RizY4SyXnCHMuVuQwmHs1H" Name="Notifications" Kind="OutputPin" />
+            <Pin Id="MmoohDgNu6HQXtmE0fc0rp" Name="On Data" Kind="OutputPin" />
+          </Node>
+          <Pad Id="VXm3R5dUadDQCf8TzwhfDk" Comment="Balloon Notification Title" Bounds="468,529,147,15" ShowValueBox="true" isIOBox="true" Value="My custom notification 🧙‍♂️">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="MRl2Ii7iqVsO2IOVzW9kId" Comment="Balloon Notification Text" Bounds="509,561,148,60" ShowValueBox="true" isIOBox="true" Value="This texts shows up in the notification badge. How cool is that? Looks like it also works with emojis.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="IPYmSjdQNwLMlFAS2cFqkS" Comment="Balloon Notification Icon" Bounds="549,630,66,15" ShowValueBox="true" isIOBox="true" Value="Info">
+            <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastSymbolSource="System.Windows.Forms.dll">
+              <Choice Kind="TypeFlag" Name="ToolTipIcon" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="DhKshYLRWrXLWDIobTw5nW" Comment="Force Show Notify Icon" Bounds="388,424,35,15" ShowValueBox="true" isIOBox="true" Value="True">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <Choice Kind="TypeFlag" Name="Boolean" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Overlay Id="VXmIG02Nd9SMOkOTmybfnS" Name="Notification balloon setup" Bounds="433,470,457,182">
+            <p:ColorIndex p:Type="Int32">5</p:ColorIndex>
+          </Overlay>
+          <Overlay Id="D1DdQrO7IQbLcMx1Z6tdLd" Name="Make notify icon always visible" Bounds="367,372,301,80">
+            <p:ColorIndex p:Type="Int32">2</p:ColorIndex>
+          </Overlay>
+          <Pad Id="Cpam0lzYZEUOA1LVaLTPqr" Bounds="130,218,167,83" ShowValueBox="true" isIOBox="true" Value="The NotifyIcon node can also be used to show popup notifications in your system tray!">
+            <p:TypeAnnotation>
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+        </Canvas>
+        <Patch Id="LRq1UnDphVgOkmhXEyHk5Y" Name="Create" />
+        <Patch Id="BEiOWVTOW7INEbOIxZ9ctg" Name="Update" />
+        <!--
+
+    ************************  ************************
+
+-->
+        <ProcessDefinition Id="AkhnnpXcRy4LTc0Pj2kTsI">
+          <Fragment Id="KHmWHjKMc2rN4bIYoyKgnX" Patch="LRq1UnDphVgOkmhXEyHk5Y" Enabled="true" />
+          <Fragment Id="NzBJy4sSZ8yOGpWG4puAIK" Patch="BEiOWVTOW7INEbOIxZ9ctg" Enabled="true" />
+        </ProcessDefinition>
+        <Link Id="EI1uytowGmhOOsZ9TWqbX7" Ids="TDKRehgRiiqOgezK1IdT69,M9QFUiHSSYUQKNm4272Fwi" />
+        <Link Id="QffcZHJq5gLP73eLZZ2FZ3" Ids="TKi5nklVjR1Pk04beuaaFN,DpBZhnl8Wv8NClC42EtEmQ" />
+        <Link Id="SGT7lePAPhfMcZGUAP78Rt" Ids="Q9lfQ5XiSZ2PmFpGodjD6o,FpWC3buV2w3QSB5t7gBKFn" />
+        <Link Id="Vr1utcBYIpkNmZTLI16f2E" Ids="MmoohDgNu6HQXtmE0fc0rp,EFqPpzlQBdGPBdyk3PimBy" />
+        <Link Id="VrcLdETZFCPL2MQTMHPZVz" Ids="VXm3R5dUadDQCf8TzwhfDk,Juxu56PSEouNxe9y8II2x4" />
+        <Link Id="I4IvgVWFW5EQX1QHofIb9j" Ids="MRl2Ii7iqVsO2IOVzW9kId,UiN6hxODDqlOORNYnRx9EC" />
+        <Link Id="UcLGl2BdViMPUSA7z8DwFo" Ids="IPYmSjdQNwLMlFAS2cFqkS,P6Lcp5qNN0pO4swvL7KIFj" />
+        <Link Id="Jk9KHEE7HzkPCNBi08B35x" Ids="DhKshYLRWrXLWDIobTw5nW,KrRcXERwm1DMz9HLOn3xUE" />
+      </Patch>
+    </Node>
+  </Patch>
+  <NugetDependency Id="JgnlYbIhDbXMXyxf4cvE8M" Location="VL.Skia" Version="2020.1.2" />
+  <NugetDependency Id="BwlhGLfD3pCLXBtvtdMZoA" Location="VL.WinFormsUtils" Version="0.0.0.0" />
+</Document>

--- a/help/Notifications/HowTo Pop a notification balloon.vl
+++ b/help/Notifications/HowTo Pop a notification balloon.vl
@@ -41,6 +41,7 @@
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="NotifyIcon" />
             </p:NodeReference>
+            <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">Low</p:HelpFocus>
             <Pin Id="M9QFUiHSSYUQKNm4272Fwi" Name="Input" Kind="InputPin" />
             <Pin Id="KrRcXERwm1DMz9HLOn3xUE" Name="Force Show Notify Icon" Kind="InputPin" DefaultValue="True">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
@@ -122,11 +123,6 @@
         </Canvas>
         <Patch Id="LRq1UnDphVgOkmhXEyHk5Y" Name="Create" />
         <Patch Id="BEiOWVTOW7INEbOIxZ9ctg" Name="Update" />
-        <!--
-
-    ************************  ************************
-
--->
         <ProcessDefinition Id="AkhnnpXcRy4LTc0Pj2kTsI">
           <Fragment Id="KHmWHjKMc2rN4bIYoyKgnX" Patch="LRq1UnDphVgOkmhXEyHk5Y" Enabled="true" />
           <Fragment Id="NzBJy4sSZ8yOGpWG4puAIK" Patch="BEiOWVTOW7INEbOIxZ9ctg" Enabled="true" />


### PR DESCRIPTION
Adds a NotifyIcon node to VL.WinFormsUtils.

This node allows to create an icon in the system tray.
- By default, the icon only shows up when the renderer is minimized. This can be overriden with a hidden pin.
- By default, uses the Form's icon. If the user has not set one, gamma's icon is retrieved. You can also set a custom icon especially for the system tray (via an hidden pin). 
- You can provide a spread of strings that will show up as entries in the icon's right-click menu. The node then outputs a spread of observables that each fire when the corresponding entry is clicked.
    - This only allows to patch "one-dimensional" menus for now, we can come up with a patchable menu similar to what Elementa has, or make use of nested spreads...
- The node also outputs some observables that fire when the icon is interacted with : click, double-click, etc. Those are available as hidden pins
- The node also allows to pop notification balloons from the systray icon.

Also added a few convenience nodes :

- Minimize, Maximize and Show to programmatically control the appearence of the Renderer

And a two howtos that show those features :

- Create a system tray icon
- Pop a notification balloon 